### PR TITLE
baseUri function to override global setup

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -124,7 +124,7 @@ function _jsonParse(body) {
  * @param {string} app - Node.js app. (e.g. Express, Koa)
  * @param {string} basePath - base path to append to the server address
  * @return {string}
- * @desc baseUri from the application, replacing any baseUri in globalSetup
+ * @desc Build the baseUri from the application, replacing any existing baseUri
  */
 function _useAppImpl (app, basePath) {
   // sanity check app
@@ -194,6 +194,16 @@ function Frisby(msg) {
 
   return this;
 }
+
+
+/**
+ * Set the baseUri, replacing any baseUri from global setup
+ * @param baseUri The new base URI
+ */
+Frisby.prototype.baseUri = function(baseUri) {
+  this.current.request.baseUri = baseUri;
+  return this;
+};
 
 
 /**

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -847,4 +847,29 @@ describe('Frisby matchers', function() {
       })
     .toss();
   });
+
+  it('baseUri should be able to override global setup', function() {
+    nock('http://httpbin.org', { allowUnmocked: true })
+     .post('/test')
+     .once()
+     .reply(200, (uri, requestBody) => requestBody);
+
+    frisby.globalSetup({
+      request: {
+        baseUri: 'http://example.com'
+      }
+    });
+
+    frisby.create(this.test.title)
+      .baseUri('http://httpbin.org')
+      .post('/test', {}, {
+        body: 'some body here'
+      })
+      .expectStatus(200)
+      .expectBodyContains('some body here')
+      .after(function() {
+        expect(this.current.outgoing.uri).to.equal('http://httpbin.org/test');
+      })
+    .toss();
+  });
 });


### PR DESCRIPTION
Thanks for this library! I'm working on some tests for [shields](https://github.com/badges/shields) (see badges/shields#927). This library seems well suited for the purpose: the tests come out really concise, it has good test coverage itself, y'all seem reponsive to PRs, and it uses Mocha and Chai.

I noticed this in the readme:

> Make output errors more useful. It can be hard to track down which assertion is causing what error.

Shields has a years-long backlog. The goal of these tests is to distribute the work of reviewing and testing to a wide net of contributors. Many of the contributors are unfamiliar with Node and JavaScript, so concise and readable tests are important, but so are good error messages.

I've started work on a POC, and I'll see what my experience with the error messaging is like, and if I have an idea about how to improve it.

Back to this PR!

***

Since global state tends to leak between tests, making them difficult to reason about, I prefer to avoid using it when possible.

In my POC, I'm wrapping the call to `frisby.create` in my own function, which has access to config and sets the base URI.