### PR TITLE
Dependencies housekeeping

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The [**IcedFrisby** Changelog](https://github.com/RobertHerhold/IcedFrisby/blob/
 
 ## Installation
 
-Install IcedFrisby from NPM:
+Install IcedFrisby and Mocha from NPM:
 
-    npm install icedfrisby --save-dev
+    npm install mocha icedfrisby --save-dev
 
 **Note:** IcedFrisby is built and tested against the latest stable versions of Node.js (4, 5, and 6)
 
@@ -92,10 +92,6 @@ Any Mocha/Chai/whatever tests can be used inside the `after` and `afterJSON` cal
 
 Run tests as you normally would with [Mocha](https://github.com/mochajs/mocha).
 
-### Install Mocha
-
-    npm install -g mocha
-
 ### Run it from the CLI
 
     cd your/project
@@ -104,9 +100,6 @@ Run tests as you normally would with [Mocha](https://github.com/mochajs/mocha).
 ---
 
 ## IcedFrisby Development
-
-### Setup
-Code quality is enforced with JSHint. You will need to install JSHint as it is run with the tests: `npm install -g jshint`
 
 ### Code Coverage
 You can assess code coverage by running `istanbul cover _mocha ./spec/**/*_spec.js -R spec`

--- a/package.json
+++ b/package.json
@@ -32,20 +32,22 @@
     "check-types": "^7.0.1",
     "joi": "^10.4.1",
     "lodash": "^4.16.6",
-    "mock-request": "^0.1.2",
     "qs": "^6.3.0",
     "request": "^2.76.0"
+  },
+  "peerDependencies": {
+    "mocha": "*"
   },
   "devDependencies": {
     "coveralls": "^2.11.14",
     "express": "^4.14.0",
-    "form-data": "2.1.4",
+    "form-data": "^2.1.4",
     "intercept-stdout": "^0.1.2",
     "istanbul": "^0.4.5",
     "jshint": "^2.9.4",
     "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
-    "mochawesome": "^2.0.4",
+    "mock-request": "^0.1.2",
     "nock": "^9.0.2"
   },
   "main": "lib/icedfrisby",


### PR DESCRIPTION
- Add mocha as a peerDependency
- Bump devDependencies
- Remove one unused devDependency
- Correctly classify mock-request as a devDependency
- Readme updates
    - Downstream users will need to install mocha.
    - There's no need to manually install jshint.