### PR TITLE
Switch from jshint to eslint, and clean

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/coverage

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,19 @@
+env:
+  node: true
+  es6: true
+  mocha: true
+
+globals:
+  expect: true
+
+extends:
+  - "eslint:recommended"
+
+rules:
+  semi: ["error", "always"]
+  no-trailing-spaces: "error"
+  eol-last: "error"
+
+  # Disable a couple rules from eslint:recommended.
+  no-unused-vars: ["error", {"args": "none"}]
+  no-console: "off"

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,11 +9,19 @@ globals:
 extends:
   - "eslint:recommended"
 
+plugins:
+  - "mocha"
+
 rules:
   semi: ["error", "always"]
+  strict: ["error", "safe"]
   no-trailing-spaces: "error"
   eol-last: "error"
 
   # Disable a couple rules from eslint:recommended.
   no-unused-vars: ["error", {"args": "none"}]
   no-console: "off"
+
+  "mocha/handle-done-callback": "error"
+  "mocha/no-global-tests": "error"
+  "mocha/no-mocha-arrows": "error"

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,0 @@
-{
-    "node": true,
-    "mocha": true,
-    "sub": true,
-    "esversion": 6
-}

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -418,8 +418,6 @@ Frisby.prototype._request = function () {
       uri = typeof args[0] === 'string' && args.shift(),
       data = typeof args[0] === 'object' && args.shift(),
       params = typeof args[0] === 'object' && args.shift(),
-      port = this.port && this.port !== 80 ? ':' + this.port : '',
-      fullUri,
       outgoing = {
         json: params.json || (this.current.request.json || false),
         uri: null,
@@ -698,7 +696,6 @@ Frisby.prototype.expectJSONTypes = function(/* [tree], jsonTest */) {
   let args     = _.slice(arguments);
   let path     = typeof args[0] === 'string' && args.shift();
   let jsonTest = typeof args[0] === 'object' && args.shift();
-  let type     = null;
 
   this.current.expects.push(function() {
     pm.matchJSONTypes({
@@ -1084,7 +1081,6 @@ Frisby.prototype.toss = function (retry) {
 
 
       function makeRequest() {
-        let requestFinished = false;
         let timeoutFinished = false;
         tries++;
 
@@ -1129,7 +1125,6 @@ Frisby.prototype.toss = function (retry) {
       // Assert callback
       // called from makeRequest if request has finished successfully
       function assert() {
-        let i;
         it.response = self.current.response;
         self.current.expectsFailed = true;
 

--- a/lib/pathMatch.js
+++ b/lib/pathMatch.js
@@ -1,5 +1,3 @@
-/*jshint node: true */
-/*jshint multistr: true */
 'use strict';
 
 var expect = require('chai').expect;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.14",
+    "eslint": "^3.19.0",
     "express": "^4.14.0",
     "form-data": "^2.1.4",
     "intercept-stdout": "^0.1.2",
@@ -60,6 +61,7 @@
   },
   "scripts": {
     "coverage": "istanbul cover _mocha --report lcovonly",
+    "eslint": "eslint '**/*.js'",
     "lint": "jshint lib/*.js",
     "test:js": "mocha",
     "test": "npm run lint && npm run test:js"

--- a/package.json
+++ b/package.json
@@ -41,11 +41,10 @@
   "devDependencies": {
     "coveralls": "^2.11.14",
     "eslint": "^3.19.0",
+    "eslint-plugin-mocha": "^4.9.0",
     "express": "^4.14.0",
-    "form-data": "^2.1.4",
     "intercept-stdout": "^0.1.2",
     "istanbul": "^0.4.5",
-    "jshint": "^2.9.4",
     "mocha": "^3.1.2",
     "mocha-lcov-reporter": "^1.2.0",
     "mock-request": "^0.1.2",
@@ -61,8 +60,7 @@
   },
   "scripts": {
     "coverage": "istanbul cover _mocha --report lcovonly",
-    "eslint": "eslint '**/*.js'",
-    "lint": "jshint lib/*.js",
+    "lint": "eslint '**/*.js'",
     "test:js": "mocha",
     "test": "npm run lint && npm run test:js"
   }

--- a/test/frisby_global.js
+++ b/test/frisby_global.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var path = require('path');
 var frisby = require('../lib/icedfrisby');
 

--- a/test/frisby_httpbin.js
+++ b/test/frisby_httpbin.js
@@ -1,10 +1,11 @@
+'use strict';
+
 var frisby = require('../lib/icedfrisby');
 var Joi = require('joi');
 var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var Readable = require('stream').Readable;
-var FormData = require('form-data');
 
 function StringStream(string, options) {
     Readable.call(this, options);
@@ -281,7 +282,7 @@ describe('Frisby live running httpbin tests', function() {
                 })
                 .toss();
     });
-  
+
   // it('sending multipart/from-data encoded bodies should work', function () {
   //
   //   var logoPath = path.resolve(__dirname, '../spec/logo-frisby.png');

--- a/test/frisby_inspect.js
+++ b/test/frisby_inspect.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var frisby = require('../lib/icedfrisby');
 var expect = require('chai').expect;
 var nock = require('nock');

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -769,9 +769,14 @@ describe('Frisby matchers', function() {
   });
 
   it('should allow for passing raw request body', function() {
-    // Intercepted with 'nock'
+    nock('http://example.com')
+      .post('/raw')
+      .reply(200, function(uri, requestBody) {
+        return requestBody;
+      });
+
     frisby.create(this.test.title)
-      .post('http://httpbin.org/raw', {}, {
+      .post('http://example.com/raw', {}, {
         body: 'some body here'
       })
       .expectStatus(200)

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var nock = require('nock');
 var fixtures = require('./fixtures/repetition_fixture.json');
 var frisby = require('../lib/icedfrisby');
@@ -36,19 +38,6 @@ var restoreGlobalSetup = function() {
   });
 };
 
-// Nock to intercept HTTP upload request
-var mock = nock('http://httpbin.org', { allowUnmocked: true })
-  .post('/file-upload')
-  .reply(200, {
-    name: 'Test Upload',
-    file: '/some/path/logo-frisby.png'
-  })
-  .post('/raw')
-  .reply(200, function(uri, requestBody) {
-    return requestBody;
-  });
-
-
 //
 // Tests run like normal Frisby specs but with 'mock' specified with a 'mock-request' object
 // These work without further 'expects' statements because Frisby generates and runs Jasmine tests
@@ -64,7 +53,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/not-found', {mock: mockFn})
       .expectStatus(404)
       .toss();
@@ -88,7 +77,7 @@ describe('Frisby matchers', function() {
     .run();
 
     mockGlobalSetup();
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .after(function(err, res, body) {
         expect(this.current.outgoing.headers['test']).to.equal('One');
@@ -110,7 +99,7 @@ describe('Frisby matchers', function() {
     .run();
 
     mockGlobalSetup();
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .addHeaders({ 'Test': 'Two' })
       .after(function(err, res, body) {
@@ -141,7 +130,7 @@ describe('Frisby matchers', function() {
 
     mockGlobalSetup();
 
-    var f1 = frisby.create(this.test.title + ' - mock test one')
+    frisby.create(this.test.title + ' - mock test one')
       .get('http://mock-request/test-object-array-ex', {mock: mockFn})
       .addHeaders({ 'Test': 'Two' })
       .after(function(err, res, body) {
@@ -150,7 +139,7 @@ describe('Frisby matchers', function() {
       })
     .toss();
 
-    var f2 = frisby.create(this.test.title + ' - mock test two')
+    frisby.create(this.test.title + ' - mock test two')
       .get('http://mock-request/test-object-array-ex2', {mock: mockFn2})
       .addHeaders({ 'Test': 'Three' })
       .after(function(err, res, body) {
@@ -246,7 +235,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONTypes('test_subjects.*', { // * == EACH object in here should match
         test_str_same: Joi.string().valid("I am the same..."),
@@ -267,7 +256,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONTypes('test_subjects.?', { // ? == ONE object in here should match (contains)
         test_str_same: Joi.string().valid("I am the same..."),
@@ -288,7 +277,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .not().expectJSON('test_subjects.?', { // ? == ONE object in 'test_subjects' array
         test_str: "I am a string two nonsense!",
@@ -402,7 +391,7 @@ describe('Frisby matchers', function() {
       })
       .run();
 
-      var f1 = frisby.create(this.test.title)
+      frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectContainsJSON('test_subjects.*', { // * == EACH object in here should match
           test_str_same: "I am the same...",
@@ -420,7 +409,7 @@ describe('Frisby matchers', function() {
       })
       .run();
 
-      var f1 = frisby.create(this.test.title)
+      frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectContainsJSON('test_subjects.?', { // ? == ONE object in here should match (contains)
           test_str: "I am a string two!",
@@ -438,7 +427,7 @@ describe('Frisby matchers', function() {
       })
       .run();
 
-      var f1 = frisby.create(this.test.title)
+      frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .not().expectContainsJSON('test_subjects.?', { // ? == ONE object in 'test_subjects' array
           test_str: "I am a string two nonsense!",
@@ -456,7 +445,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .not().expectJSONTypes('test_subjects.?', { // ? == ONE object in 'test_subjects' array
         test_str: Joi.boolean(),
@@ -475,7 +464,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', 3)
       .expectJSONLength('test_subjects.0', 4)
@@ -493,7 +482,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', 4)
       .toss();
@@ -509,7 +498,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .not()
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', 3)
@@ -527,7 +516,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '<=3')
       .expectJSONLength('test_subjects.0', '<=4')
@@ -545,7 +534,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '<=4')
       .toss();
@@ -561,7 +550,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '<4')
       .expectJSONLength('test_subjects.0', '<5')
@@ -579,7 +568,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '<5')
       .toss();
@@ -595,7 +584,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '>=3')
       .expectJSONLength('test_subjects.0', '>=4')
@@ -613,7 +602,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '>=4')
       .toss();
@@ -629,7 +618,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '>2')
       .expectJSONLength('test_subjects.0', '>3')
@@ -647,7 +636,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '>3')
       .toss();
@@ -663,7 +652,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '3')
       .expectJSONLength('test_subjects.0', '4')
@@ -681,7 +670,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '4')
       .toss();
@@ -696,7 +685,7 @@ describe('Frisby matchers', function() {
       })
     .run();
 
-    var f1 = frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/not-found', {mock: mockFn})
       .expectStatus(404)
       .toss();

--- a/test/frisby_output.js
+++ b/test/frisby_output.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const chai = require('chai');
 const intercept = require("intercept-stdout");
 const nock = require('nock');
@@ -28,6 +30,8 @@ var restoreGlobalSetup = function() {
 describe('console output', function() {
   var warning = '\u001b[33m\u001b[1mWARNING - content-type is json but body type is not set\u001b[22m\u001b[39m\n';
 
+  afterEach(restoreGlobalSetup);
+
     it('should warn developers if there is a header with \'json\' but the body type is not JSON', function() {
         // Mock API
         nock('http://mock-request/', {
@@ -52,7 +56,7 @@ describe('console output', function() {
             .toss();
 
         unhook();
-        chai.assert.equal(warning, stdout, 'expect stdout to have a specific warning')
+        chai.assert.equal(warning, stdout, 'expect stdout to have a specific warning');
     });
 
     it('should NOT warn developers that "there is a header with \'json\' but the body type is not JSON" because there is no body provided', function() {
@@ -77,6 +81,6 @@ describe('console output', function() {
             .toss();
 
         unhook();
-        chai.assert.equal("", stdout, 'expect stdout to be empty')
+        chai.assert.equal("", stdout, 'expect stdout to be empty');
     });
 });

--- a/test/frisby_useApp.js
+++ b/test/frisby_useApp.js
@@ -1,4 +1,3 @@
-/*jshint -W030 */ // .exist causes "Expected an assignment or function call and instead saw an expression". Disable.
 'use strict';
 
 var fs = require('fs');
@@ -39,7 +38,7 @@ describe('IcedFrisby useApp(app)', function() {
             res.send('^.^');
         });
 
-        var server = app.listen(4000, function() {
+        app.listen(4000, function() {
             frisby.create(this.test.title)
                 .useApp(app)
                 .get('/')

--- a/test/pathMatch.js
+++ b/test/pathMatch.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var pm = require('../lib/pathMatch');
 
 var Joi = require('joi');


### PR DESCRIPTION
This switches the linter from JSHint to ESLint. ESLint is a superior tool for a number of reasons:

- Has a large and highly engaged core team with awesome community culture
- Has a vast community, which means tons of plugins
    - There's one for Mocha, which I've included
- Great error messages
- Autofix, where many errors can be fixed automatically with the `--fix` flag
- The "recommended" rules catch a bunch of things which JSHint did not
- It's great at enforcing style conventions as well as common errors. Before ESLint, you had to use a combination of JSHint and JSCS. (JSCS has now merged with ESLint.)
- It's style agnostic, which means we can find a style preset we like, or pick our own rules
- Rules are carefully implemented and tested. False positives are extremely rare, once config is set up correctly.