### PR TITLE
Extract a _start() method from toss() to aid readability

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -1069,11 +1069,52 @@ Frisby.prototype.setResponseHeader = function(key, value) {
   return this;
 };
 
+/**
+ * Register the current Frisby test with Mocha.
+ */
+Frisby.prototype.toss = function () {
+  const self = this;
 
-Frisby.prototype._performInspections = function () {
-  for (let i = 0; i < this.current.inspections.length; i++) {
-    const fn = this.current.inspections[i];
-    fn.call(this);
+  describe(self.current.describe, function () {
+    it("\n\t[ " + self.current.itInfo + " ]", function (done) {
+      self._start(this, done);
+    });
+  });
+};
+
+Frisby.prototype._start = function (mochaContext, done) {
+  // mock results_
+  mochaContext.results_ = {
+    failedCount: 0
+  };
+  mochaContext.request = this.current.outgoing;
+
+  // launch request
+  // repeat request for this.current.retry times if request does not respond with this._timeout ms (except for POST requests)
+  mochaContext.tries = 0;
+  mochaContext.retries = (this.current.outgoing.method.toUpperCase() ==
+    "POST") ? 0 : this.current.retry;
+
+  for(let i=0; i < this.current.before.length; i++) {
+    const fn = this.current.before[i];
+    if(false !== this._exceptionHandler) {
+      try {
+        fn.call(this);
+      } catch(e) {
+        this._exceptionHandler(e);
+      }
+    } else {
+      fn.call(this);
+    }
+  }
+
+  // wait optinally, launch request
+  if (this.current.waits > 0) {
+    setTimeout(() => {
+      this._makeRequest(mochaContext, done);
+    }, this.current.waits);
+  } else {
+    this._makeRequest(mochaContext, done);
   }
 };
 
@@ -1110,6 +1151,12 @@ Frisby.prototype._makeRequest = function (mochaContext, done) {
   });
 };
 
+Frisby.prototype._performInspections = function () {
+  for (let i = 0; i < this.current.inspections.length; i++) {
+    const fn = this.current.inspections[i];
+    fn.call(this);
+  }
+};
 
 // called from makeRequest if request has finished successfully
 Frisby.prototype._invokeExpects = function (mochaContext, done) {
@@ -1141,7 +1188,6 @@ Frisby.prototype._invokeExpects = function (mochaContext, done) {
 
   this._finish(null, done);
 };
-
 
 // Execute further expects for the current spec (called from _invokeExpects)
 Frisby.prototype._finish = function (err, done) {
@@ -1175,54 +1221,4 @@ Frisby.prototype._finish = function (err, done) {
   } else {
     done();
   }
-};
-
-
-/**
- * @return {object}
- * @desc Run the current Frisby test
- */
-Frisby.prototype.toss = function () {
-  const self = this;
-
-  // Assemble all tests and RUN them!
-  describe(self.current.describe, function () {
-    it("\n\t[ " + self.current.itInfo + " ]", function (done) {
-      const mochaContext = this;
-
-      // mock results_
-      mochaContext.results_ = {
-        failedCount: 0
-      };
-      mochaContext.request = self.current.outgoing;
-
-      // launch request
-      // repeat request for self.current.retry times if request does not respond with self._timeout ms (except for POST requests)
-      mochaContext.tries = 0;
-      mochaContext.retries = (self.current.outgoing.method.toUpperCase() ==
-        "POST") ? 0 : self.current.retry;
-
-      for(let i=0; i < self.current.before.length; i++) {
-        const fn = self.current.before[i];
-        if(false !== self._exceptionHandler) {
-          try {
-            fn.call(self);
-          } catch(e) {
-            self._exceptionHandler(e);
-          }
-        } else {
-          fn.call(self);
-        }
-      }
-
-      // wait optinally, launch request
-      if (self.current.waits > 0) {
-        setTimeout(() => {
-          self._makeRequest(mochaContext, done);
-        }, self.current.waits);
-      } else {
-        self._makeRequest(mochaContext, done);
-      }
-    });
-  });
 };


### PR DESCRIPTION
- Sequence test methods in order of invocation
- Clarify in comments that toss() registers the tests. They are not run
  immediately.
- toss() does not return a value