### PR TITLE
Enforce indent and remove semicolons

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,7 +13,8 @@ plugins:
   - "mocha"
 
 rules:
-  semi: ["error", "always"]
+  semi: ["error", "never"]
+  indent: ["error", 2, { "SwitchCase": 1 }]
   strict: ["error", "safe"]
   no-trailing-spaces: "error"
   eol-last: "error"

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -1,6 +1,4 @@
-/* eslint indent: ["error", 2, { "SwitchCase": 1 }] */
-
-'use strict';
+'use strict'
 
 
 /*
@@ -17,17 +15,17 @@
  */
 
 
-const _ = require('lodash');
-const chai = require('chai');
-const chalk = require('chalk');
-const https = require('https');
-const pkg = require('../package.json');
-const pm = require('./pathMatch');
-const qs = require('qs');
-const request = require('request');
-const stream = require('stream').Stream;
-const util = require('util');
-const MultiError = require('verror').MultiError;
+const _ = require('lodash')
+const chai = require('chai')
+const chalk = require('chalk')
+const https = require('https')
+const pkg = require('../package.json')
+const pm = require('./pathMatch')
+const qs = require('qs')
+const request = require('request')
+const stream = require('stream').Stream
+const util = require('util')
+const MultiError = require('verror').MultiError
 
 
 // setup defaults
@@ -38,12 +36,12 @@ const _icedfrisbyDefaults = _.constant({
     json: false,
     baseUri: ''
   }
-});
+})
 
 
 // initialize setup defaults
-let _init = _icedfrisbyDefaults();
-let _initDefined = false;
+let _init = _icedfrisbyDefaults()
+let _initDefined = false
 
 
 /**
@@ -57,11 +55,11 @@ function globalSetupDefined(init, obj) {
   if (init.failOnMultiSetup || obj.failOnMultiSetup) {
     throw new Error(chalk.red.bold('ERROR - ' +
       'globalSetup() called more than once, failOnMultiSetup set to true')
-    );
+    )
   } else {
     console.log(chalk.yellow.bold('WARNING - ' +
       'globalSetup() called more than once, may cause unstable behavior')
-    );
+    )
   }
 }
 
@@ -73,14 +71,14 @@ function globalSetupDefined(init, obj) {
  * @desc verifies proper headers
  */
 function _hasHeader(headername, headers) {
-  const headerNames = Object.keys(headers || {});
-  const lowerNames = headerNames.map(function (name) {return name.toLowerCase();});
-  const lowerName = headername.toLowerCase();
+  const headerNames = Object.keys(headers || {})
+  const lowerNames = headerNames.map(function (name) {return name.toLowerCase()})
+  const lowerName = headername.toLowerCase()
 
   for (let i=0;i<lowerNames.length;i++) {
-    if (lowerNames[i] === lowerName) return headerNames[i];
+    if (lowerNames[i] === lowerName) return headerNames[i]
   }
-  return false;
+  return false
 }
 
 
@@ -92,15 +90,15 @@ function _hasHeader(headername, headers) {
  * @desc parse response body as json
  */
 function _jsonParse(body) {
-  let json = "";
+  let json = ""
   try {
-    json = (typeof body === "object") ? body : JSON.parse(body);
+    json = (typeof body === "object") ? body : JSON.parse(body)
   } catch (e) {
     throw new Error(
       "Error parsing JSON string: " + e.message + "\n\tGiven: " + body
-    );
+    )
   }
-  return json;
+  return json
 }
 
 
@@ -112,16 +110,16 @@ function _jsonParse(body) {
  */
 function _useAppImpl (app, basePath) {
   // sanity check app
-  if (!app) { throw new Error('No app provided'); }
+  if (!app) { throw new Error('No app provided') }
 
   // coerce basePath to a string
-  basePath = basePath ? basePath + '' : '';
+  basePath = basePath ? basePath + '' : ''
 
-  const address = app.listen().address();
-  const port = address.port;
-  const protocol = app instanceof https.Server ? 'https' : 'http';
+  const address = app.listen().address()
+  const port = address.port
+  const protocol = app instanceof https.Server ? 'https' : 'http'
 
-  return protocol + '://127.0.0.1:' + port + basePath;
+  return protocol + '://127.0.0.1:' + port + basePath
 }
 
 
@@ -135,18 +133,18 @@ class Frisby {
    * @return {object}
    */
   constructor (msg) {
-    const clone = _.cloneDeep(Frisby.globalSetup());
+    const clone = _.cloneDeep(Frisby.globalSetup())
 
     if(clone.request && clone.request.headers) {
-      const headers = {};
+      const headers = {}
       _.forEach(clone.request.headers, function(val, key) {
-        headers[(key+"").toLowerCase()] = val+"";
-      });
-      clone.request.headers = headers;
+        headers[(key+"").toLowerCase()] = val+""
+      })
+      clone.request.headers = headers
     }
 
     // Optional exception handler
-    this._exceptionHandler = false;
+    this._exceptionHandler = false
 
     // Spec storage
     this.current = {
@@ -175,13 +173,13 @@ class Frisby {
         body: null,
         time: 0
       }
-    };
+    }
 
-    this.currentRequestFinished = false;
-    this._timeout = clone.timeout || 5000;
-    this.responseType = 'json';
+    this.currentRequestFinished = false
+    this._timeout = clone.timeout || 5000
+    this.responseType = 'json'
 
-    return this;
+    return this
   }
 
 
@@ -193,16 +191,16 @@ class Frisby {
    */
   static globalSetup (obj) {
     if (!_.isUndefined(obj)) {
-      if (_initDefined) { globalSetupDefined(_init, obj); }
+      if (_initDefined) { globalSetupDefined(_init, obj) }
 
-      _initDefined = true;
-      _init = _.merge(_.cloneDeep(_icedfrisbyDefaults()), obj);
+      _initDefined = true
+      _init = _.merge(_.cloneDeep(_icedfrisbyDefaults()), obj)
 
       if(_init.useApp) {
-        _init.request.baseUri = _useAppImpl(_init.useApp);
+        _init.request.baseUri = _useAppImpl(_init.useApp)
       }
     }
-    return _init;
+    return _init
   }
 
 
@@ -210,7 +208,7 @@ class Frisby {
    * Main Frisby method used to start new spec tests
    */
   static create (msg) {
-    return new Frisby(msg);
+    return new Frisby(msg)
   }
 
 
@@ -219,8 +217,8 @@ class Frisby {
    * @param baseUri The new base URI
    */
   baseUri (baseUri) {
-    this.current.request.baseUri = baseUri;
-    return this;
+    this.current.request.baseUri = baseUri
+    return this
   }
 
 
@@ -231,8 +229,8 @@ class Frisby {
    * @desc Setup the request to use a passed in Node http.Server app
    */
   useApp (app, basePath) {
-    this.current.request.baseUri = _useAppImpl(app, basePath);
-    return this;
+    this.current.request.baseUri = _useAppImpl(app, basePath)
+    return this
   }
 
 
@@ -243,10 +241,10 @@ class Frisby {
    */
   timeout (ms) {
     if(!ms) {
-      return this._timeout;
+      return this._timeout
     }
-    this._timeout = ms;
-    return this;
+    this._timeout = ms
+    return this
   }
 
 
@@ -255,8 +253,8 @@ class Frisby {
    * @desc Reset Frisby global and setup options
    */
   reset () {
-    this.current.request = _.cloneDeep(_icedfrisbyDefaults().request);
-    return this;
+    this.current.request = _.cloneDeep(_icedfrisbyDefaults().request)
+    return this
   }
 
 
@@ -267,8 +265,8 @@ class Frisby {
    * @desc Add HTTP header by key and value
    */
   not () {
-    this.current.isNot = true;
-    return this;
+    this.current.isNot = true
+    return this
   }
 
 
@@ -279,8 +277,8 @@ class Frisby {
    * @desc Add HTTP header by key and value
    */
   addHeader (header, content) {
-    this.current.request.headers[(header+"").toLowerCase()] = content+"";
-    return this;
+    this.current.request.headers[(header+"").toLowerCase()] = content+""
+    return this
   }
 
 
@@ -290,11 +288,11 @@ class Frisby {
    * @desc Add group of HTTP headers together
    */
   addHeaders (headers) {
-    const self = this;
+    const self = this
     _.forEach(headers, function(val, key) {
-      self.addHeader(key, val);
-    });
-    return this;
+      self.addHeader(key, val)
+    })
+    return this
   }
 
 
@@ -304,8 +302,8 @@ class Frisby {
    * @desc Remove HTTP header from outgoing request by key
    */
   removeHeader (key) {
-    delete this.current.request.headers[(key+"").toLowerCase()];
-    return this;
+    delete this.current.request.headers[(key+"").toLowerCase()]
+    return this
   }
 
 
@@ -321,8 +319,8 @@ class Frisby {
       sendImmediately: !digest,
       user: user,
       pass: pass
-    };
-    return this;
+    }
+    return this
   }
 
 
@@ -336,7 +334,7 @@ class Frisby {
    * .get('/resource', {key: value})
    */
   get (uri, params) {
-    return this._request.apply(this, ['GET', uri, null, params]);
+    return this._request.apply(this, ['GET', uri, null, params])
   }
 
 
@@ -349,7 +347,7 @@ class Frisby {
    * .patch('/resource', {key: value}, {key: value})
    */
   patch (uri, data, params) {
-    return this._request.apply(this, ['PATCH', uri, data, params]);
+    return this._request.apply(this, ['PATCH', uri, data, params])
   }
 
 
@@ -363,7 +361,7 @@ class Frisby {
    * .post('/resource', {key: value}, {key: value})
    */
   post (uri, data, params) {
-    return this._request.apply(this, ['POST', uri, data, params]);
+    return this._request.apply(this, ['POST', uri, data, params])
   }
 
 
@@ -377,7 +375,7 @@ class Frisby {
    * .put('/resource', {key: value}, {key: value})
    */
   put (uri, data, params) {
-    return this._request.apply(this, ['PUT', uri, data, params]);
+    return this._request.apply(this, ['PUT', uri, data, params])
   }
 
 
@@ -391,7 +389,7 @@ class Frisby {
    * .delete('/resource', {key: value}, {key: value})
    */
   delete (uri, data, params) {
-    return this._request.apply(this, ['DELETE', uri, data, params]);
+    return this._request.apply(this, ['DELETE', uri, data, params])
   }
 
 
@@ -404,7 +402,7 @@ class Frisby {
    * .head('/resource', {key: value})
    */
   head (uri, params) {
-    return this._request.apply(this, ['HEAD', uri, null, params]);
+    return this._request.apply(this, ['HEAD', uri, null, params])
   }
 
 
@@ -417,7 +415,7 @@ class Frisby {
    * .options('/resource', {key: value}, {key: value})
    */
   options (uri, params) {
-    return this._request.apply(this, ['OPTIONS', uri, null, params]);
+    return this._request.apply(this, ['OPTIONS', uri, null, params])
   }
 
 
@@ -430,38 +428,38 @@ class Frisby {
    * @desc _request object
    */
   _request () {
-    const self = this;
-    const args = _.slice(arguments);
-    const method = args.shift();
-    const uri = typeof args[0] === 'string' && args.shift();
-    let data = typeof args[0] === 'object' && args.shift();
-    const params = typeof args[0] === 'object' && args.shift();
+    const self = this
+    const args = _.slice(arguments)
+    const method = args.shift()
+    const uri = typeof args[0] === 'string' && args.shift()
+    let data = typeof args[0] === 'object' && args.shift()
+    const params = typeof args[0] === 'object' && args.shift()
     const outgoing = {
       json: params.json || (this.current.request.json || false),
       uri: null,
       body: params.body || undefined,
       method: 'GET',
       headers: {}
-    };
+    }
 
     // Explicit setting of 'body' param overrides data
     if (params.body) {
-      data = params.body;
+      data = params.body
     }
 
     // Merge 'current' request options for current request
-    _.extend(outgoing, this.current.request, params || {});
+    _.extend(outgoing, this.current.request, params || {})
 
     // Normalize content-type
-    const contentTypeKey = _hasHeader('content-type', outgoing.headers);
+    const contentTypeKey = _hasHeader('content-type', outgoing.headers)
     if (contentTypeKey !== 'content-type') {
-      outgoing.headers['content-type'] = outgoing.headers[contentTypeKey];
-      delete outgoing.headers[contentTypeKey];
+      outgoing.headers['content-type'] = outgoing.headers[contentTypeKey]
+      delete outgoing.headers[contentTypeKey]
     }
 
     // Ensure we have at least one 'content-type' header
     if (_.isUndefined(outgoing.headers['content-type'])) {
-      outgoing.headers['content-type'] = 'application/x-www-form-urlencoded';
+      outgoing.headers['content-type'] = 'application/x-www-form-urlencoded'
     }
 
     // If the content-type header contains 'json' but outgoing.json is false, the user likely messed up. Warn them.
@@ -470,11 +468,11 @@ class Frisby {
       console.warn(
         chalk.yellow.bold(
           'WARNING - content-type is json but body type is not set')
-      );
+      )
     }
 
     // Set outgoing URI
-    outgoing.uri = (this.current.request.baseUri || '') + uri;
+    outgoing.uri = (this.current.request.baseUri || '') + uri
 
     //
     // If the user has provided data, assume that it is query string
@@ -485,18 +483,18 @@ class Frisby {
       if (outgoing.json) {
 
         const isContentTypeHeaderMissing = outgoing.headers['content-type'] &&
-          outgoing.headers['content-type'].indexOf('application/json') === -1;
+          outgoing.headers['content-type'].indexOf('application/json') === -1
 
         if (isContentTypeHeaderMissing) {
-          outgoing.headers['content-type'] = 'application/json';
+          outgoing.headers['content-type'] = 'application/json'
         }
 
-        outgoing.body = data;
+        outgoing.body = data
       } else if (!outgoing.body) {
         if (data instanceof Buffer) {
-          outgoing.body = data;
+          outgoing.body = data
         } else if (!(data instanceof stream)) {
-          outgoing.body = qs.stringify(data);
+          outgoing.body = qs.stringify(data)
         }
       }
     }
@@ -505,47 +503,47 @@ class Frisby {
     // Set the `uri` and `method` properties of the request options `outgoing`
     // using the information provided to this instance and `_request()`.
     //
-    outgoing.method = method;
+    outgoing.method = method
 
     //
     // Store outgoing request on current Frisby object for inspection if needed
     //
-    this.current.outgoing = outgoing;
+    this.current.outgoing = outgoing
 
     //
     // Create the description for this test based on the METHOD and URL
     //
-    this.current.itInfo = method.toUpperCase() + ' ' + outgoing.uri;
+    this.current.itInfo = method.toUpperCase() + ' ' + outgoing.uri
 
     //
     // Determine test runner function (request or provided mock)
     //
-    const runner = params.mock || request;
+    const runner = params.mock || request
 
     //
     // Add the topic for the specified request to the context of the current
     // batch used by this suite.
     //
     this.current.it = function (cb) {
-      self.currentRequestFinished = false;
-      const start = (new Date()).getTime();
+      self.currentRequestFinished = false
+      const start = (new Date()).getTime()
       const runCallback = function(err, res, body) {
 
         // Timeout is now handled by request
         if(err) {
-          body = "[IcedFrisby] Destination URL may be down or URL is invalid, " + err;
+          body = "[IcedFrisby] Destination URL may be down or URL is invalid, " + err
         }
 
-        const diff = (new Date()).getTime() - start;
+        const diff = (new Date()).getTime() - start
 
-        self.currentRequestFinished = {err: err, res: res, body: body, req: outgoing};
+        self.currentRequestFinished = {err: err, res: res, body: body, req: outgoing}
 
         // Convert header names to lowercase
-        const headers = {};
+        const headers = {}
         if (res) {
           _.forEach(res.headers, function(val, key) {
-            headers[(key+"").toLowerCase()] = val;
-          });
+            headers[(key+"").toLowerCase()] = val
+          })
         }
         // Store relevant current response parts
         self.current.response = {
@@ -554,40 +552,40 @@ class Frisby {
           headers: headers,
           body: body,
           time: diff
-        };
+        }
 
         // call caller's callback
         if (cb && typeof cb === "function") {
-          cb(self.current.response);
+          cb(self.current.response)
         }
-      };
+      }
 
-      outgoing.timeout = self._timeout;
+      outgoing.timeout = self._timeout
 
-      let req = null;
+      let req = null
 
       // Handle forms (normal data with {form: true} in params options)
       if(!_.isUndefined(params.form) && params.form === true) {
-        delete outgoing.headers['content-type'];
-        req = runner(outgoing, runCallback);
-        const form = req.form();
+        delete outgoing.headers['content-type']
+        req = runner(outgoing, runCallback)
+        const form = req.form()
         for(const field in data) {
-          form.append(field, data[field]);
+          form.append(field, data[field])
         }
       } else {
-        req = runner(outgoing, runCallback);
+        req = runner(outgoing, runCallback)
       }
 
       if ((data instanceof stream) && (
         outgoing.method === 'POST' ||
         outgoing.method === 'PUT' ||
         outgoing.method === 'PATCH')) {
-        data.pipe(req);
+        data.pipe(req)
       }
 
-    };
+    }
 
-    return this;
+    return this
   }
 
 
@@ -597,11 +595,11 @@ class Frisby {
    * @desc HTTP max response time expect helper
    */
   expectMaxResponseTime (ms) {
-    const self = this;
+    const self = this
     this.current.expects.push(function() {
-      chai.expect(self.current.response.time).to.be.lessThan(ms);
-    });
-    return this;
+      chai.expect(self.current.response.time).to.be.lessThan(ms)
+    })
+    return this
   }
 
 
@@ -611,11 +609,11 @@ class Frisby {
    * @desc HTTP status code expect helper
    */
   expectStatus (statusCode) {
-    const self = this;
+    const self = this
     this.current.expects.push(function() {
-      chai.expect(self.current.response.status).to.equal(statusCode);
-    });
-    return this;
+      chai.expect(self.current.response.status).to.equal(statusCode)
+    })
+    return this
   }
 
 
@@ -626,19 +624,19 @@ class Frisby {
    * @desc HTTP header expect helper
    */
   expectHeader (header, content) {
-    const self = this;
+    const self = this
 
-    header = (header + "").toLowerCase();
+    header = (header + "").toLowerCase()
 
     this.current.expects.push(function () {
       if (typeof self.current.response.headers[header] !== "undefined") {
         chai.expect(self.current.response.headers[header].toLowerCase()).to
-          .equal(content.toLowerCase());
+          .equal(content.toLowerCase())
       } else {
-        throw new Error("Header '" + header + "' not present in HTTP response");
+        throw new Error("Header '" + header + "' not present in HTTP response")
       }
-    });
-    return this;
+    })
+    return this
   }
 
 
@@ -649,18 +647,18 @@ class Frisby {
    * @desc HTTP header expect helper (using 'contains' instead of 'equals')
    */
   expectHeaderContains (header, content) {
-    const self = this;
-    header = (header + "").toLowerCase();
+    const self = this
+    header = (header + "").toLowerCase()
     this.current.expects.push(function () {
       if (typeof self.current.response.headers[header] !== "undefined") {
         chai.expect(self.current.response.headers[header].toLowerCase()).to
-          .contain(content.toLowerCase());
+          .contain(content.toLowerCase())
       } else {
         throw new Error("Header '" + header +
-          "' not present in HTTP response");
+          "' not present in HTTP response")
       }
-    });
-    return this;
+    })
+    return this
   }
 
 
@@ -671,18 +669,18 @@ class Frisby {
    * @desc HTTP header expect helper regular expression match
    */
   expectHeaderToMatch (header, pattern) {
-    const self = this;
-    header = (header + "").toLowerCase();
+    const self = this
+    header = (header + "").toLowerCase()
     this.current.expects.push(function () {
       if (typeof self.current.response.headers[header] !== "undefined") {
         chai.expect(self.current.response.headers[header].toLowerCase()).to
-          .match(pattern);
+          .match(pattern)
       } else {
         throw new Error("Header '" + header + "' does not match pattern '" +
-          pattern + "' in HTTP response");
+          pattern + "' in HTTP response")
       }
-    });
-    return this;
+    })
+    return this
   }
 
 
@@ -692,17 +690,17 @@ class Frisby {
    * @desc HTTP body expect helper
    */
   expectBodyContains (content) {
-    const self = this;
+    const self = this
     this.current.expects.push(function () {
       if (!_.isUndefined(self.current.response.body)) {
-        chai.expect(self.current.response.body).to.contain(content);
+        chai.expect(self.current.response.body).to.contain(content)
       } else {
         throw new Error(
           "No HTTP response body was present or HTTP response was empty"
-        );
+        )
       }
-    });
-    return this;
+    })
+    return this
   }
 
 
@@ -712,10 +710,10 @@ class Frisby {
    * @desc Helper to check parse HTTP response body as JSON and check key types
    */
   expectJSONTypes (/* [tree], jsonTest */) {
-    const self = this;
-    const args = _.slice(arguments);
-    const path = typeof args[0] === 'string' && args.shift();
-    const jsonTest = typeof args[0] === 'object' && args.shift();
+    const self = this
+    const args = _.slice(arguments)
+    const path = typeof args[0] === 'string' && args.shift()
+    const jsonTest = typeof args[0] === 'object' && args.shift()
 
     this.current.expects.push(function() {
       pm.matchJSONTypes({
@@ -723,9 +721,9 @@ class Frisby {
         jsonTest: jsonTest,
         isNot: self.current.isNot,
         path: path
-      });
-    });
-    return this;
+      })
+    })
+    return this
   }
 
   /**
@@ -734,10 +732,10 @@ class Frisby {
    * @desc Helper to check JSON response body exactly matches a provided object
    */
   expectJSON (jsonTest) {
-    const self = this;
-    const args = _.slice(arguments);
-    const path = typeof args[0] === 'string' && args.shift();
-    jsonTest = typeof args[0] === 'object' && args.shift();
+    const self = this
+    const args = _.slice(arguments)
+    const path = typeof args[0] === 'string' && args.shift()
+    jsonTest = typeof args[0] === 'object' && args.shift()
 
     this.current.expects.push(function() {
       pm.matchJSON({
@@ -745,9 +743,9 @@ class Frisby {
         jsonTest: jsonTest,
         isNot: self.current.isNot,
         path: path
-      });
-    });
-    return this;
+      })
+    })
+    return this
   }
 
 
@@ -757,10 +755,10 @@ class Frisby {
    * @desc Helper to check JSON response contains a provided object
    */
   expectContainsJSON (jsonTest) {
-    const self = this;
-    const args = _.slice(arguments);
-    const path = typeof args[0] === 'string' && args.shift();
-    jsonTest = typeof args[0] === 'object' && args.shift();
+    const self = this
+    const args = _.slice(arguments)
+    const path = typeof args[0] === 'string' && args.shift()
+    jsonTest = typeof args[0] === 'object' && args.shift()
 
     this.current.expects.push(function() {
       pm.matchContainsJSON({
@@ -768,9 +766,9 @@ class Frisby {
         jsonTest: jsonTest,
         isNot: self.current.isNot,
         path: path
-      });
-    });
-    return this;
+      })
+    })
+    return this
   }
 
 
@@ -780,24 +778,24 @@ class Frisby {
    * @desc Helper to check response body as JSON and check array or object length
    */
   expectJSONLength (expectedLength) {
-    const self = this;
-    const args = _.slice(arguments);
-    const path = _.isString(args[0]) && args.shift(); // optional 1st parameter
-    expectedLength = (_.isNumber(args[0]) || _.isString(args[0])) && args.shift(); // 1st or 2nd parameter
-    let lengthSegments = null;
+    const self = this
+    const args = _.slice(arguments)
+    const path = _.isString(args[0]) && args.shift() // optional 1st parameter
+    expectedLength = (_.isNumber(args[0]) || _.isString(args[0])) && args.shift() // 1st or 2nd parameter
+    let lengthSegments = null
 
     // if expectedLength is a string, we have to parse out the sign
     if (!_.isNumber(expectedLength)) {
-      const sign = /\D+/.exec(expectedLength);
+      const sign = /\D+/.exec(expectedLength)
       lengthSegments = {
         count: parseInt(/\d+/.exec(expectedLength), 10),
         sign: sign ? _.trim(sign) : null // extract the sign, e.g. <, <=, >, >= and trim out whitespace
-      };
+      }
     } else {
       lengthSegments = {
         count: expectedLength,
         sign: null
-      };
+      }
     }
 
     this.current.expects.push(function () {
@@ -806,10 +804,10 @@ class Frisby {
         jsonTest: lengthSegments, // we aren't testing any JSON here, just use this to pass in the length segments
         isNot: self.current.isNot,
         path: path
-      });
-    });
+      })
+    })
 
-    return this;
+    return this
   }
 
 
@@ -819,10 +817,10 @@ class Frisby {
    * @desc inspection of data after request is made but before test is completed
    */
   inspect (cb) {
-    const self = this;
+    const self = this
 
     if (!cb) {
-      return self;
+      return self
     }
 
     // Node invokes inspect() when printing formatting objects. Guess if that's
@@ -830,15 +828,15 @@ class Frisby {
     // disabling custom inspection.
     // https://nodejs.org/api/util.html#util_custom_inspection_functions_on_objects
     if ((typeof cb) !== 'function') {
-      return util.inspect(self, { customInspect: false });
+      return util.inspect(self, { customInspect: false })
     }
 
     this.current.inspections.push(function () {
       cb.call(this, self.current.response.error, self.currentRequestFinished
         .req, self.currentRequestFinished.res, self.current.response.body,
-        self.current.response.headers);
-    });
-    return this;
+        self.current.response.headers)
+    })
+    return this
   }
 
 
@@ -851,11 +849,11 @@ class Frisby {
     this.inspect(
       function (err, req, res, body) {
         if (message) {
-          console.log(message);
+          console.log(message)
         }
-        console.log(req);
-      });
-    return this;
+        console.log(req)
+      })
+    return this
   }
 
 
@@ -868,11 +866,11 @@ class Frisby {
     this.inspect(
       function (err, req, res, body) {
         if (message) {
-          console.log(message);
+          console.log(message)
         }
-        console.log(res);
-      });
-    return this;
+        console.log(res)
+      })
+    return this
   }
 
 
@@ -885,11 +883,11 @@ class Frisby {
     this.inspect(
       function (err, req, res, body) {
         if (message) {
-          console.log(message);
+          console.log(message)
         }
-        console.log(res.headers);
-      });
-    return this;
+        console.log(res.headers)
+      })
+    return this
   }
 
 
@@ -902,11 +900,11 @@ class Frisby {
     this.inspect(
       function (err, req, res, body) {
         if (message) {
-          console.log(message);
+          console.log(message)
         }
-        console.log(body);
-      });
-    return this;
+        console.log(body)
+      })
+    return this
   }
 
 
@@ -919,11 +917,11 @@ class Frisby {
     this.inspect(
       function (err, req, res, body) {
         if (message) {
-          console.log(message);
+          console.log(message)
         }
-        console.log(util.inspect(_jsonParse(body), false, 10, true));
-      });
-    return this;
+        console.log(util.inspect(_jsonParse(body), false, 10, true))
+      })
+    return this
   }
 
 
@@ -936,11 +934,11 @@ class Frisby {
     this.inspect(
       function (err, req, res, body) {
         if (message) {
-          console.log(message);
+          console.log(message)
         }
-        console.log(res.statusCode);
-      });
-    return this;
+        console.log(res.statusCode)
+      })
+    return this
   }
 
 
@@ -951,11 +949,11 @@ class Frisby {
    * @desc retry the request (good for flaky,slow tests)
    */
   retry (count, ms) {
-    this.current.retry = count;
+    this.current.retry = count
     if (typeof backoff !== "undefined") {
-      this.current.retry_backoff = ms;
+      this.current.retry_backoff = ms
     }
-    return this;
+    return this
   }
 
 
@@ -965,8 +963,8 @@ class Frisby {
    * @desc time to wait before attempting to the test
    */
   waits (ms) {
-    this.current.waits = ms;
-    return this;
+    this.current.waits = ms
+    return this
   }
 
 
@@ -976,8 +974,8 @@ class Frisby {
    * @desc callback function to run before the request is made
    */
   before (cb) {
-    this.current.before.push(cb);
-    return this;
+    this.current.before.push(cb)
+    return this
   }
 
 
@@ -987,12 +985,12 @@ class Frisby {
    * @desc callback function to run after test is completed
    */
   after (cb) {
-    const self = this;
+    const self = this
     this.current.after.push(function () {
       cb.call(this, self.current.response.error, self.currentRequestFinished.res,
-                    self.current.response.body,  self.current.response.headers);
-    });
-    return this;
+                    self.current.response.body,  self.current.response.headers)
+    })
+    return this
   }
 
   /**
@@ -1010,13 +1008,13 @@ class Frisby {
    * })
    */
   afterJSON (cb) {
-    const self = this;
+    const self = this
     this.current.after.push(function() {
-      const responseHeaders = _jsonParse(self.current.response.headers);
-      const bodyJSON = _jsonParse(self.current.response.body);
-      cb.call(this, bodyJSON, responseHeaders);
-    });
-    return this;
+      const responseHeaders = _jsonParse(self.current.response.headers)
+      const bodyJSON = _jsonParse(self.current.response.body)
+      cb.call(this, bodyJSON, responseHeaders)
+    })
+    return this
   }
 
 
@@ -1027,8 +1025,8 @@ class Frisby {
    * @return {object}
    */
   finally (cb) {
-    this.current.finally.push(cb);
-    return this;
+    this.current.finally.push(cb)
+    return this
   }
 
 
@@ -1037,10 +1035,10 @@ class Frisby {
    */
   exceptionHandler (fn) {
     if(_.isUndefined(fn)) {
-      return this._exceptionHandler;
+      return this._exceptionHandler
     }
-    this._exceptionHandler = fn;
-    return this;
+    this._exceptionHandler = fn
+    return this
   }
 
 
@@ -1052,8 +1050,8 @@ class Frisby {
    * @desc set response type (default 'json')
    */
   setResponseType (type) {
-    this.responseType = type;
-    return this;
+    this.responseType = type
+    return this
   }
 
 
@@ -1063,9 +1061,9 @@ class Frisby {
    * @desc set JSON response
    */
   setResponseJSON (json) {
-    this.currentRequestFinished = true;
-    this.current.response.body = JSON.stringify(json);
-    return this;
+    this.currentRequestFinished = true
+    this.current.response.body = JSON.stringify(json)
+    return this
   }
 
 
@@ -1075,9 +1073,9 @@ class Frisby {
    * @desc set response body
    */
   setResponseBody (body) {
-    this.currentRequestFinished = true;
-    this.current.response.body = body;
-    return this;
+    this.currentRequestFinished = true
+    this.current.response.body = body
+    return this
   }
 
 
@@ -1087,8 +1085,8 @@ class Frisby {
    * @desc set response headers, see addHeaders
    */
   setResponseHeaders (headers) {
-    this.current.response.headers = headers;
-    return this;
+    this.current.response.headers = headers
+    return this
   }
 
 
@@ -1099,8 +1097,8 @@ class Frisby {
    * @desc set response headers, see addHeader
    */
   setResponseHeader (key, value) {
-    this.current.response.headers[key.toLowerCase()] = value.toLowerCase();
-    return this;
+    this.current.response.headers[key.toLowerCase()] = value.toLowerCase()
+    return this
   }
 
 
@@ -1108,84 +1106,84 @@ class Frisby {
    * Register the current Frisby test with Mocha.
    */
   toss () {
-    const self = this;
+    const self = this
 
     describe(self.current.describe, function () {
       it("\n\t[ " + self.current.itInfo + " ]", function (done) {
-        self._start(done);
-      });
-    });
+        self._start(done)
+      })
+    })
   }
 
 
   _start (done) {
     // Repeat request for this.current.retry times if request does not respond
     // with this._timeout ms (except for POST requests).
-    this.current.tries = 0;
+    this.current.tries = 0
     this.current.retries = this.current.outgoing.method.toUpperCase() === 'POST'
       ? 0
-      : this.current.retry;
+      : this.current.retry
 
     // When an error occurs in a before() hook, stop executing before hooks and
     // move on to finally() hooks. This mimics Mocha's behavior of before() and
     // after() hooks. A dev-provided exception handler overrides this behavior.
     for(let i=0; i < this.current.before.length; i++) {
-      const fn = this.current.before[i];
+      const fn = this.current.before[i]
       try {
-        fn.call(this);
+        fn.call(this)
       } catch(e) {
         if (false === this._exceptionHandler) {
-          this.current.failures.push(e);
-          this._finish(done);
-          return;
+          this.current.failures.push(e)
+          this._finish(done)
+          return
         } else {
-          this._exceptionHandler(e);
+          this._exceptionHandler(e)
         }
       }
     }
 
     if (this.current.waits > 0) {
-      setTimeout(() => { this._makeRequest(done); }, this.current.waits);
+      setTimeout(() => { this._makeRequest(done) }, this.current.waits)
     } else {
-      this._makeRequest(done);
+      this._makeRequest(done)
     }
   }
 
 
   _makeRequest (done) {
-    const self = this;
-    let timeoutFinished = false;
-    self.current.tries++;
+    const self = this
+    let timeoutFinished = false
+    self.current.tries++
 
     const timeoutId = setTimeout(function maxWait() {
-      timeoutFinished = true;
+      timeoutFinished = true
       if (self.current.tries < self.current.retries + 1) {
-        process.stdout.write('R');
-        self._makeRequest(done);
+        process.stdout.write('R')
+        self._makeRequest(done)
       } else {
         // In frisby it.results_ would trigger a failure for jasmine but has
         // no effect in mocha. We need to indicate a failure for tests that
         // reach this point.
-        const err = Error('Destination URL may be down or URL is invalid');
-        self.current.failures.push(err);
-        self._finish(done);
+        const err = Error('Destination URL may be down or URL is invalid')
+        self.current.failures.push(err)
+        self._finish(done)
       }
-    }, self._timeout);
+    }, self._timeout)
 
     self.current.it(function (data) {
       if (!timeoutFinished) {
-        clearTimeout(timeoutId);
-        self._performInspections.call(self);
-        self._invokeExpects.call(self, done);
+        clearTimeout(timeoutId)
+        self._performInspections.call(self)
+        self._invokeExpects.call(self, done)
       }
-    });
+    })
   }
 
 
   _performInspections () {
     for (let i = 0; i < this.current.inspections.length; i++) {
-      const fn = this.current.inspections[i];
-      fn.call(this);
+      const fn = this.current.inspections[i]
+      fn.call(this)
     }
   }
 
@@ -1197,31 +1195,31 @@ class Frisby {
     // 'expectJSON' and 'expectJSONTypes', with nested JSON syntax etc.)
     for (let i = 0; i < this.current.expects.length; i++) {
       try {
-        this.current.expects[i].call(null);
+        this.current.expects[i].call(null)
       } catch (e) {
         if (false === this._exceptionHandler) {
-          this.current.failures.push(e);
-          break;
+          this.current.failures.push(e)
+          break
         } else {
-          this._exceptionHandler.call(this, e);
+          this._exceptionHandler.call(this, e)
         }
       }
     }
 
-    this._finish(done);
+    this._finish(done)
   }
 
 
   // Execute further expects for the current spec (called from _invokeExpects)
   _finish (done) {
     const didPass = this.current.failures.length === 0,
-      didFail = !didPass;
+      didFail = !didPass
 
     if (didFail && this.current.outgoing.inspectOnFailure) {
       console.log(this.current.itInfo +
-        ' has FAILED with the following response:');
-      this.inspectStatus();
-      this.inspectJSON();
+        ' has FAILED with the following response:')
+      this.inspectStatus()
+      this.inspectJSON()
     }
 
     // Once a failure has occurred, stop running any remaining after() hooks.
@@ -1229,15 +1227,15 @@ class Frisby {
       // REQUIRES count for EACH loop iteration (i.e. DO NOT OPTIMIZE THIS LOOP)
       // this enables after to add more after to do things (like inspectJSON)
       for (let i = 0; i < this.current.after.length; i++) {
-        const fn = this.current.after[i];
+        const fn = this.current.after[i]
         try {
-          fn.call(this);
+          fn.call(this)
         } catch (e) {
           if (false === this._exceptionHandler) {
-            this.current.failures.push(e);
-            break;
+            this.current.failures.push(e)
+            break
           } else {
-            this._exceptionHandler(e);
+            this._exceptionHandler(e)
           }
         }
       }
@@ -1246,30 +1244,30 @@ class Frisby {
     // Stop after the first error, mimicking Mocha's behavior in after()
     // callbacks.
     for (let i = 0; i < this.current.finally.length; i++) {
-      const fn = this.current.finally[i];
+      const fn = this.current.finally[i]
       try {
-        fn.call(this);
+        fn.call(this)
       } catch (e) {
         if (false === this._exceptionHandler) {
-          this.current.failures.push(e);
-          break;
+          this.current.failures.push(e)
+          break
         } else {
-          this._exceptionHandler(e);
+          this._exceptionHandler(e)
         }
       }
     }
 
-    let retError = null;
+    let retError = null
     if (this.current.failures.length === 1) {
-      retError = this.current.failures[0];
+      retError = this.current.failures[0]
     } else if (this.current.failures.length > 1) {
-      retError = new MultiError(this.current.failures);
+      retError = new MultiError(this.current.failures)
     }
 
     // Finally call done to finish spec.
-    done(retError);
+    done(retError)
   }
 }
-module.exports = Frisby;
+module.exports = Frisby
 
-Frisby.version = pkg.version;
+Frisby.version = pkg.version

--- a/lib/pathMatch.js
+++ b/lib/pathMatch.js
@@ -1,40 +1,40 @@
-'use strict';
+'use strict'
 
-const expect = require('chai').expect;
-const _ = require('lodash');
-const checkTypes = require('check-types');
-const Joi = require('joi');
+const expect = require('chai').expect
+const _ = require('lodash')
+const checkTypes = require('check-types')
+const Joi = require('joi')
 
 // setup Chai
-const chai = require('chai');
-global.expect = chai.expect;
-chai.config.includeStack = false;
-chai.use(require('chai-things')); // used to include.something...
-chai.use(require('chai-subset')); // used to see if an object contains another
+const chai = require('chai')
+global.expect = chai.expect
+chai.config.includeStack = false
+chai.use(require('chai-things')) // used to include.something...
+chai.use(require('chai-subset')) // used to see if an object contains another
 
-const pathMatch = {};
+const pathMatch = {}
 
 // performs a setup operation by checking the input data and merging the input data with a set of defaults
 // returns the result of merging the default options and the input data
 function setup(check) {
-    if (!check) {
-        throw new Error('Data to match is not defined');
-    } else if (!check.jsonBody) {
-        throw new Error('jsonBody is not defined');
-    } else if (!check.jsonTest) {
-        throw new Error('jsonTest is not defined');
-    }
+  if (!check) {
+    throw new Error('Data to match is not defined')
+  } else if (!check.jsonBody) {
+    throw new Error('jsonBody is not defined')
+  } else if (!check.jsonTest) {
+    throw new Error('jsonTest is not defined')
+  }
 
     // define the defaults
-    const defaults = {
-        isNot: false,
-        path: undefined
+  const defaults = {
+    isNot: false,
+    path: undefined
         // jsonBody will be present
         // jsonTest will be present
-    };
+  }
 
     // merge the passed in values with the defaults
-    return _.merge(defaults, check);
+  return _.merge(defaults, check)
 }
 
 // applies a path traversal by navigating through the jsonBody
@@ -48,398 +48,398 @@ function applyPath(path, jsonBody, isNot) {
     // * path cannot start with ? or * and have more stuff after
 
     // states the last option in the path
-    let lastOption;
+  let lastOption
 
     // split up the path by '.'
-    const pathSegments = path.split('.');
+  const pathSegments = path.split('.')
     // temporarially store the last option
-    const tmpLast = pathSegments[pathSegments.length - 1];
+  const tmpLast = pathSegments[pathSegments.length - 1]
     // if the last option is not a '*' or '?', set it to unefined as the developer didn't specify one
-    if ('*' === tmpLast || '?' === tmpLast) {
-        lastOption = tmpLast;
-    }
+  if ('*' === tmpLast || '?' === tmpLast) {
+    lastOption = tmpLast
+  }
 
-    try {
+  try {
         // break apart the path and iterate through the keys to traverse through the JSON object
-        _.forEach(pathSegments, function(segment) {
+    _.forEach(pathSegments, function(segment) {
             // if the next 'segment' isn't actually a special character, traverse through the object
-            if('*' !== segment && '?' !== segment) {
-                jsonBody = jsonBody[segment];
-            }
-        });
-    } catch(e) {
-        if(!isNot) {
-            throw e;
-        } else {
-            console.warn("[IcedFrisby] You attempted to traverse through an object with a path ('" + path + "') that did not exist in the object. \
-This issue was suppressed because you specified the isNot option. This behavior is usually considered an anti-pattern. Use a schema check instead.");
-        }
+      if('*' !== segment && '?' !== segment) {
+        jsonBody = jsonBody[segment]
+      }
+    })
+  } catch(e) {
+    if(!isNot) {
+      throw e
+    } else {
+      console.warn("[IcedFrisby] You attempted to traverse through an object with a path ('" + path + "') that did not exist in the object. \
+This issue was suppressed because you specified the isNot option. This behavior is usually considered an anti-pattern. Use a schema check instead.")
     }
+  }
 
-    return {
-        lastOption: lastOption,
-        jsonBody: jsonBody
-    };
+  return {
+    lastOption: lastOption,
+    jsonBody: jsonBody
+  }
 }
 
 // creates and returns an error object saying 1 of X objects should have matched
 function expectedMatchErr(itemCount) {
-    const objPlural = itemCount > 1 ? "objects" : "object";
-    return new Error("Expected 1 out of " + itemCount + " " + objPlural + " to match provided JSON types");
+  const objPlural = itemCount > 1 ? "objects" : "object"
+  return new Error("Expected 1 out of " + itemCount + " " + objPlural + " to match provided JSON types")
 }
 
 // performs a complete JSON match
 pathMatch.matchJSON = function(check) {
     // setup the data (validate check object, apply defaults)
-    check = setup(check);
+  check = setup(check)
 
     // states the last option specified in the path (undefined, '*', or '?')
-    let lastOption;
+  let lastOption
 
     // traverse through a deep object if needed
-    if(check.path) {
-        const results = applyPath(check.path, check.jsonBody, check.isNot);
-        lastOption = results.lastOption;
-        check.jsonBody = results.jsonBody;
-    }
+  if(check.path) {
+    const results = applyPath(check.path, check.jsonBody, check.isNot)
+    lastOption = results.lastOption
+    check.jsonBody = results.jsonBody
+  }
 
     // EACH item in array should match
-    if('*' === lastOption) {
+  if('*' === lastOption) {
         // assert that jsonBody is an array
-        checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody));
+    checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-        _.forEach(check.jsonBody, function(json) {
-            if (check.isNot) {
-                expect(json).to.not.deep.equal(check.jsonTest);
-            } else {
-                expect(json).to.deep.equal(check.jsonTest);
-            }
-        });
+    _.forEach(check.jsonBody, function(json) {
+      if (check.isNot) {
+        expect(json).to.not.deep.equal(check.jsonTest)
+      } else {
+        expect(json).to.deep.equal(check.jsonTest)
+      }
+    })
 
     // ONE item in array should match
-    } else if('?' === lastOption) {
+  } else if('?' === lastOption) {
         // assert that jsonBody is an array
-        checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody));
+    checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-        const itemCount = check.jsonBody.length;
+    const itemCount = check.jsonBody.length
 
         // check if there are any objects to match against. Don't do this for the .not case - having 0 elements would be valid.
-        if (0 === itemCount && !check.isNot) {
-            throw new Error('There are no JSON objects to match against');
-        }
+    if (0 === itemCount && !check.isNot) {
+      throw new Error('There are no JSON objects to match against')
+    }
 
-        if (check.isNot) {
-            expect(check.jsonBody).to.not.include.something.that.deep.equals(check.jsonTest);
-        } else {
-            expect(check.jsonBody).to.include.something.that.deep.equals(check.jsonTest);
-        }
+    if (check.isNot) {
+      expect(check.jsonBody).to.not.include.something.that.deep.equals(check.jsonTest)
+    } else {
+      expect(check.jsonBody).to.include.something.that.deep.equals(check.jsonTest)
+    }
 
     // Normal matcher, entire object/array should match
+  } else {
+    if (check.isNot) {
+      expect(check.jsonBody).to.not.deep.equal(check.jsonTest)
     } else {
-        if (check.isNot) {
-            expect(check.jsonBody).to.not.deep.equal(check.jsonTest);
-        } else {
-            expect(check.jsonBody).to.deep.equal(check.jsonTest);
-        }
+      expect(check.jsonBody).to.deep.equal(check.jsonTest)
     }
-};
+  }
+}
 
 // performs a partial JSON match where test object should be contained in the JSON response object
 pathMatch.matchContainsJSON = function(check) {
     // setup the data (validate check object, apply defaults)
-    check = setup(check);
+  check = setup(check)
 
     // states the last option specified in the path (undefined, '*', or '?')
-    let lastOption;
+  let lastOption
 
     // traverse through a deep object if needed
-    if(check.path) {
-        const results = applyPath(check.path, check.jsonBody, check.isNot);
-        lastOption = results.lastOption;
-        check.jsonBody = results.jsonBody;
-    }
+  if(check.path) {
+    const results = applyPath(check.path, check.jsonBody, check.isNot)
+    lastOption = results.lastOption
+    check.jsonBody = results.jsonBody
+  }
 
-    if (checkTypes.not.object(check.jsonBody) && checkTypes.not.array(check.jsonBody)) {
-        throw new Error("ContainsJSON does not support non-Array/Object datatypes. Got " + typeof(check.jsonBody) + " in JSON body");
-    } else if (checkTypes.not.object(check.jsonTest) && checkTypes.not.array(check.jsonTest)) {
-        throw new Error("ContainsJSON does not support non-Array/Object datatypes. Got " + typeof(check.jsonBody) + " in JSON test field");
-    }
+  if (checkTypes.not.object(check.jsonBody) && checkTypes.not.array(check.jsonBody)) {
+    throw new Error("ContainsJSON does not support non-Array/Object datatypes. Got " + typeof(check.jsonBody) + " in JSON body")
+  } else if (checkTypes.not.object(check.jsonTest) && checkTypes.not.array(check.jsonTest)) {
+    throw new Error("ContainsJSON does not support non-Array/Object datatypes. Got " + typeof(check.jsonBody) + " in JSON test field")
+  }
 
     // EACH item in array should match
-    if('*' === lastOption) {
+  if('*' === lastOption) {
         // assert that jsonBody is an array
-        checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody));
+    checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-        _.forEach(check.jsonBody, function(json) {
-            if (check.isNot) {
-                expect(json).to.not.containSubset(check.jsonTest);
-            } else {
-                expect(json).to.containSubset(check.jsonTest);
-            }
-        });
+    _.forEach(check.jsonBody, function(json) {
+      if (check.isNot) {
+        expect(json).to.not.containSubset(check.jsonTest)
+      } else {
+        expect(json).to.containSubset(check.jsonTest)
+      }
+    })
 
         // ONE item in array should match
-    } else if('?' === lastOption) {
-        checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody));
+  } else if('?' === lastOption) {
+    checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-        const itemCount = check.jsonBody.length;
-        let errorCount = 0;
+    const itemCount = check.jsonBody.length
+    let errorCount = 0
 
         // check if there are any objects to match against. Don't do this for the .not case - having 0 elements would be valid.
-        if (0 === itemCount && !check.isNot) {
-            throw new Error("There are no JSON objects to match against");
-        }
+    if (0 === itemCount && !check.isNot) {
+      throw new Error("There are no JSON objects to match against")
+    }
 
-        for (let i = 0; i < itemCount; i++) {
-            try {
-                expect(check.jsonBody[i]).to.containSubset(check.jsonTest);
-            } catch (err) {
+    for (let i = 0; i < itemCount; i++) {
+      try {
+        expect(check.jsonBody[i]).to.containSubset(check.jsonTest)
+      } catch (err) {
                 /* istanbul ignore else */
-                if ('AssertionError' === err.name) {
+        if ('AssertionError' === err.name) {
                     // didn't match this object, increment number of errors
-                    errorCount++;
-                } else {
+          errorCount++
+        } else {
                     // some error with the IcedFrisby or a dependency
-                    throw err;
-                }
-            }
+          throw err
         }
+      }
+    }
 
         // If all errors, test fails
-        if(itemCount === errorCount && !check.isNot) {
-            throw expectedMatchErr(itemCount);
-        }
+    if(itemCount === errorCount && !check.isNot) {
+      throw expectedMatchErr(itemCount)
+    }
 
     // Normal matcher, entire object should be contained
-    } else {
+  } else {
             // handle (array of) objects, strings and numbers cases
-            if (check.isNot) {
-                expect(check.jsonBody).to.not.containSubset(check.jsonTest);
-            } else {
-                expect(check.jsonBody).to.containSubset(check.jsonTest);
-            }
+    if (check.isNot) {
+      expect(check.jsonBody).to.not.containSubset(check.jsonTest)
+    } else {
+      expect(check.jsonBody).to.containSubset(check.jsonTest)
     }
-};
+  }
+}
 
 // performs a complete JSON type match with Joi
 pathMatch.matchJSONTypes = function(check) {
     // setup the data (validate check object, apply defaults)
-    check = setup(check);
+  check = setup(check)
 
     // states the last option specified in the path (undefined, '*', or '?')
-    let lastOption;
+  let lastOption
 
     // traverse through a deep object if needed
-    if(check.path) {
-        const results = applyPath(check.path, check.jsonBody, check.isNot);
-        lastOption = results.lastOption;
-        check.jsonBody = results.jsonBody;
-    }
+  if(check.path) {
+    const results = applyPath(check.path, check.jsonBody, check.isNot)
+    lastOption = results.lastOption
+    check.jsonBody = results.jsonBody
+  }
 
     // keep track of errors for * and ? paths
-    let errorCount = 0;
+  let errorCount = 0
 
     // EACH item in array should match
-    if('*' === lastOption) {
-        checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody));
+  if('*' === lastOption) {
+    checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-        _.forEach(check.jsonBody, function(json) {
+    _.forEach(check.jsonBody, function(json) {
             // expect(json).toContainJsonTypes(jsonTest, self.current.isNot);
-            Joi.validate(json, check.jsonTest, function(err, value) {
-                if (err) {
-                    if (check.isNot) {
+      Joi.validate(json, check.jsonTest, function(err, value) {
+        if (err) {
+          if (check.isNot) {
                         // there is an error but isNot case is true. Increment counter.
-                        errorCount++;
-                    } else {
-                        throw err;
-                    }
-                }
-            });
-        });
+            errorCount++
+          } else {
+            throw err
+          }
+        }
+      })
+    })
 
         // if this is the isNot case, ALL the validations should have failed for the '*' case
-        if (check.isNot) {
-            const delta = check.jsonBody.length - errorCount;
+    if (check.isNot) {
+      const delta = check.jsonBody.length - errorCount
             // if the error count is not the same as the number of elements, something validated successfully - which is a problem
-            if (0 !== delta) {
-                throw new Error('Expected all objects to be invalid but ' + delta + '/' + check.jsonBody.length + ' objects validated successfully');
-            }
-        }
+      if (0 !== delta) {
+        throw new Error('Expected all objects to be invalid but ' + delta + '/' + check.jsonBody.length + ' objects validated successfully')
+      }
+    }
 
 
     // ONE item in array should match
-    } else if('?' === lastOption) {
-        checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody));
+  } else if('?' === lastOption) {
+    checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-        const itemCount = check.jsonBody.length;
+    const itemCount = check.jsonBody.length
 
         // check if there are any objects to match against. Don't do this for the .not case - having 0 elements would be valid.
-        if (0 === itemCount && !check.isNot) {
-            throw new Error("There are no JSON objects to match against");
-        }
+    if (0 === itemCount && !check.isNot) {
+      throw new Error("There are no JSON objects to match against")
+    }
 
         // callback function for a Joi validation
-        const joiCb = function(err, value) {
-            if (err) {
+    const joiCb = function(err, value) {
+      if (err) {
                 // didn't match this object, increment number of errors
-                errorCount++;
-            }
-        };
+        errorCount++
+      }
+    }
 
-        for (let i = 0; i < itemCount; i++) {
-            Joi.validate(check.jsonBody[i], check.jsonTest, joiCb);
-        }
+    for (let i = 0; i < itemCount; i++) {
+      Joi.validate(check.jsonBody[i], check.jsonTest, joiCb)
+    }
 
         // If all errors, test fails
-        if(itemCount === errorCount && !check.isNot) {
-            throw expectedMatchErr(itemCount);
-        }
-    // Normal matcher, entire object/array should match
-    } else {
-        Joi.validate(check.jsonBody, check.jsonTest, function(err, value) {
-            if (err && !check.isNot) {
-                throw err;
-            }
-        });
+    if(itemCount === errorCount && !check.isNot) {
+      throw expectedMatchErr(itemCount)
     }
-};
+    // Normal matcher, entire object/array should match
+  } else {
+    Joi.validate(check.jsonBody, check.jsonTest, function(err, value) {
+      if (err && !check.isNot) {
+        throw err
+      }
+    })
+  }
+}
 
 // performs a length match on a string or object
 pathMatch.matchJSONLength = function(check) {
     // setup the data (validate check object, apply defaults)
-    check = setup(check);
+  check = setup(check)
 
-    checkTypes.assert.object(check.jsonTest, 'JSON test must be an object');
-    checkTypes.assert.integer(check.jsonTest.count, 'The count field must be an integer');
+  checkTypes.assert.object(check.jsonTest, 'JSON test must be an object')
+  checkTypes.assert.integer(check.jsonTest.count, 'The count field must be an integer')
     // if the sign exists, check it
-    if (check.jsonTest.sign) {
-        checkTypes.assert.string(check.jsonTest.sign);
-    } else {
+  if (check.jsonTest.sign) {
+    checkTypes.assert.string(check.jsonTest.sign)
+  } else {
         // default the sign char to null. This is necessary for the switch statement.
-        check.jsonTest.sign = null;
-    }
+    check.jsonTest.sign = null
+  }
 
     // states the last option specified in the path (undefined, '*', or '?')
-    let lastOption;
+  let lastOption
 
     // traverse through a deep object if needed
-    if (check.path) {
-        const results = applyPath(check.path, check.jsonBody, check.isNot);
-        lastOption = results.lastOption;
-        check.jsonBody = results.jsonBody;
-    }
+  if (check.path) {
+    const results = applyPath(check.path, check.jsonBody, check.isNot)
+    lastOption = results.lastOption
+    check.jsonBody = results.jsonBody
+  }
 
     // keep track of errors for * and ? paths
-    let errorCount = 0;
+  let errorCount = 0
 
     // EACH item in array should match
-    if ('*' === lastOption) {
-        checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody));
+  if ('*' === lastOption) {
+    checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-        _.forEach(check.jsonBody, function(json) {
-            try {
-                expectLength(json, check.jsonTest);
-            } catch (err) {
+    _.forEach(check.jsonBody, function(json) {
+      try {
+        expectLength(json, check.jsonTest)
+      } catch (err) {
                 /* istanbul ignore if */
-                if ('AssertionError' !== err.name) {
+        if ('AssertionError' !== err.name) {
                     // some error with the IcedFrisby or a dependency
-                    throw err;
-                }
+          throw err
+        }
 
-                if (check.isNot) {
+        if (check.isNot) {
                     // there is an error but isNot case is true. Increment counter.
-                    errorCount++;
-                } else {
-                    throw err;
-                }
-            }
-        });
+          errorCount++
+        } else {
+          throw err
+        }
+      }
+    })
 
         // if this is the isNot case, ALL the validations should have failed for the '*' case
-        if (check.isNot) {
-            const delta = check.jsonBody.length - errorCount;
+    if (check.isNot) {
+      const delta = check.jsonBody.length - errorCount
             // if the error count is not the same as the number of elements, something validated successfully - which is a problem
-            if (0 !== delta) {
-                throw new Error('Expected all lengths to be invalid but ' + delta + '/' + check.jsonBody.length + ' lengths validated successfully');
-            }
-        }
+      if (0 !== delta) {
+        throw new Error('Expected all lengths to be invalid but ' + delta + '/' + check.jsonBody.length + ' lengths validated successfully')
+      }
+    }
 
 
     // ONE item in array should match
-    } else if ('?' === lastOption) {
-        checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody));
+  } else if ('?' === lastOption) {
+    checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-        const itemCount = check.jsonBody.length;
+    const itemCount = check.jsonBody.length
 
         // check if there are any objects to match against. Don't do this for the .not case - having 0 elements would be valid.
-        if (0 === itemCount && !check.isNot) {
-            throw new Error("There are no JSON objects to match against");
+    if (0 === itemCount && !check.isNot) {
+      throw new Error("There are no JSON objects to match against")
+    }
+
+    _.forEach(check.jsonBody, function(json) {
+      try {
+        expectLength(json, check.jsonTest)
+      } catch (err) {
+                /* istanbul ignore if */
+        if ('AssertionError' !== err.name) {
+                    // some error with the IcedFrisby or a dependency
+          throw err
         }
 
-        _.forEach(check.jsonBody, function(json) {
-            try {
-                expectLength(json, check.jsonTest);
-            } catch (err) {
-                /* istanbul ignore if */
-                if ('AssertionError' !== err.name) {
-                    // some error with the IcedFrisby or a dependency
-                    throw err;
-                }
-
-                errorCount++;
-            }
-        });
+        errorCount++
+      }
+    })
 
         // If all errors, test fails
-        if (itemCount === errorCount && !check.isNot) {
-            throw expectedMatchErr(itemCount);
-        }
-    // Normal matcher, entire object/array should match
-    } else {
-        try {
-            expectLength(check.jsonBody, check.jsonTest);
-        } catch (err) {
-            if (!check.isNot) {
-                throw err;
-            }
-        }
+    if (itemCount === errorCount && !check.isNot) {
+      throw expectedMatchErr(itemCount)
     }
-};
+    // Normal matcher, entire object/array should match
+  } else {
+    try {
+      expectLength(check.jsonBody, check.jsonTest)
+    } catch (err) {
+      if (!check.isNot) {
+        throw err
+      }
+    }
+  }
+}
 
 // expect length function for matchJSONLength that does the comparison operations
 const expectLength = function(jsonBody, lengthSegments) {
-    let len = 0;
+  let len = 0
 
-    if (_.isObject(jsonBody)) {
-        len = Object.keys(jsonBody).length;
-    } else {
-        len = jsonBody.length;
-    }
+  if (_.isObject(jsonBody)) {
+    len = Object.keys(jsonBody).length
+  } else {
+    len = jsonBody.length
+  }
 
-    let msg; // message for expectation result
+  let msg // message for expectation result
     //TODO: in the future, use expect(jsonBody).to.have.length.below(lengthSegments.count + 1); or similar for non-objects to get better assertion messages
-    switch (lengthSegments.sign) {
-        case "<=":
-            msg = "Expected length to be less than or equal to " + lengthSegments.count + ", but got " + len;
-            expect(len).to.be.lessThan(lengthSegments.count + 1, msg);
-            break;
-        case "<":
-            msg = "Expected length to be less than " + lengthSegments.count + ", but got " + len;
-            expect(len).to.be.lessThan(lengthSegments.count, msg);
-            break;
-        case ">=":
-            msg = "Expected length to be greater than or equal " + lengthSegments.count + ", but got " + len;
-            expect(len).to.be.greaterThan(lengthSegments.count - 1, msg);
-            break;
-        case ">":
-            msg = "Expected length to be greater than " + lengthSegments.count + ", but got " + len;
-            expect(len).to.be.greaterThan(lengthSegments.count, msg);
-            break;
-        case null:
-            msg = "Expected length to be " + lengthSegments.count + ", but got " + len;
-            expect(len).to.equal(lengthSegments.count, msg);
-            break;
-    } //end switch
-};
+  switch (lengthSegments.sign) {
+    case "<=":
+      msg = "Expected length to be less than or equal to " + lengthSegments.count + ", but got " + len
+      expect(len).to.be.lessThan(lengthSegments.count + 1, msg)
+      break
+    case "<":
+      msg = "Expected length to be less than " + lengthSegments.count + ", but got " + len
+      expect(len).to.be.lessThan(lengthSegments.count, msg)
+      break
+    case ">=":
+      msg = "Expected length to be greater than or equal " + lengthSegments.count + ", but got " + len
+      expect(len).to.be.greaterThan(lengthSegments.count - 1, msg)
+      break
+    case ">":
+      msg = "Expected length to be greater than " + lengthSegments.count + ", but got " + len
+      expect(len).to.be.greaterThan(lengthSegments.count, msg)
+      break
+    case null:
+      msg = "Expected length to be " + lengthSegments.count + ", but got " + len
+      expect(len).to.equal(lengthSegments.count, msg)
+      break
+  } //end switch
+}
 
-module.exports = pathMatch;
+module.exports = pathMatch

--- a/test/app_integration_express/expressApp.js
+++ b/test/app_integration_express/expressApp.js
@@ -1,25 +1,25 @@
 /* istanbul ignore next */
-'use strict';
+'use strict'
 
-var express = require('express');
-var app = express();
+var express = require('express')
+var app = express()
 
 app.get('/', function(req, res) {
-    res.send('Hello World!');
-});
+  res.send('Hello World!')
+})
 
 /* istanbul ignore next */
 // prevent the app from starting if it is required as a module
 if (!module.parent) {
-    var server = app.listen(3000, function() {
+  var server = app.listen(3000, function() {
 
-        var host = server.address().address;
-        var port = server.address().port;
+    var host = server.address().address
+    var port = server.address().port
 
-        console.log('Example app listening at http://%s:%s', host, port);
+    console.log('Example app listening at http://%s:%s', host, port)
 
-    });
+  })
 }
 
 // export the application
-module.exports = app;
+module.exports = app

--- a/test/expressApp.js
+++ b/test/expressApp.js
@@ -1,19 +1,19 @@
-'use strict';
+'use strict'
 
-var frisby = require('./../lib/icedfrisby');
-var app = require('./app_integration_express/expressApp');
+var frisby = require('./../lib/icedfrisby')
+var app = require('./app_integration_express/expressApp')
 
 describe('Example Express app integration', function() {
-    frisby.create('should start the app on an ephemeral port and request')
+  frisby.create('should start the app on an ephemeral port and request')
         .useApp(app)
         .get('/')
         .expectStatus(200)
         .expectBodyContains('Hello World!')
-        .toss();
+        .toss()
 
-    frisby.create('should start the app on an ephemeral port and request')
+  frisby.create('should start the app on an ephemeral port and request')
         .useApp(app, '/a/path')
         .get('/not-found')
         .expectStatus(404)
-        .toss();
-});
+        .toss()
+})

--- a/test/frisby_global.js
+++ b/test/frisby_global.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-var path = require('path');
-var frisby = require('../lib/icedfrisby');
+var path = require('path')
+var frisby = require('../lib/icedfrisby')
 
 describe('Frisby object setup', function() {
 
@@ -13,104 +13,104 @@ describe('Frisby object setup', function() {
         json: false,
         baseUri: ''
       }
-    });
-  });
+    })
+  })
 
   it('should have empty request properties on creation', function() {
-    var f1 = frisby.create('test 1');
+    var f1 = frisby.create('test 1')
 
     expect(f1.current.request).to.deep.equal({
       headers: {},
       inspectOnFailure: false,
       json: false,
       baseUri: ''
-    });
-  });
+    })
+  })
 
   it('should be independent of other Frisby objects', function() {
-    var f1 = frisby.create('test 1');
-    var f2 = frisby.create('test 2');
+    var f1 = frisby.create('test 1')
+    var f2 = frisby.create('test 2')
 
     // Equal setup
-    expect(f1.current.request).to.deep.equal(f2.current.request);
+    expect(f1.current.request).to.deep.equal(f2.current.request)
 
     // Different describe statements
-    expect(f1.current.describe).not.to.deep.equal(f2.current.describe);
+    expect(f1.current.describe).not.to.deep.equal(f2.current.describe)
 
     // Add header only to f1
     f1.addHeaders({
       'Accept': 'application/json'
-    });
+    })
     f2.addHeaders({
       'Accept': 'application/x-www-form-urlencoded'
-    });
+    })
 
     // Different setup
-    expect(f1.current.request).not.to.deep.equal(f2.current.request);
-  });
+    expect(f1.current.request).not.to.deep.equal(f2.current.request)
+  })
 
   it('should be able to useApp', function() {
-      frisby.globalSetup({
-        useApp: require(path.join(__dirname, './app_integration_express/expressApp.js'))
-      });
+    frisby.globalSetup({
+      useApp: require(path.join(__dirname, './app_integration_express/expressApp.js'))
+    })
 
-      frisby.create();
-  });
+    frisby.create()
+  })
 
-   it('should be able to addHeader when global request headers is not configured', function() {
-     frisby.globalSetup({
-       request: {
-         inspectOnFailure: false,
-         json: false
-       }
-     });
+  it('should be able to addHeader when global request headers is not configured', function() {
+    frisby.globalSetup({
+      request: {
+        inspectOnFailure: false,
+        json: false
+      }
+    })
 
-     frisby.create('mytest').addHeader('Cookie', 'key=value').reset();
-   });
+    frisby.create('mytest').addHeader('Cookie', 'key=value').reset()
+  })
 
   it('should be able to add and remove headers', function() {
-    var f1 = frisby.create('test 1');
+    var f1 = frisby.create('test 1')
 
     // Add header only to f1
     f1.addHeaders({
       'accept': 'application/json'
-    });
+    })
 
     // verify that the header is set correctly
     expect(f1.current.request.headers).to.deep.equal({
-        'accept': 'application/json'
-    });
+      'accept': 'application/json'
+    })
 
     // remove the header
-    f1.removeHeader('accept');
+    f1.removeHeader('accept')
 
     // verify that the header is set correctly
-    expect(f1.current.request.headers).to.deep.equal({});
-  });
+    expect(f1.current.request.headers).to.deep.equal({})
+  })
 
   it('should be overrite headers with the same key', function() {
-    var f1 = frisby.create('test 1');
+    var f1 = frisby.create('test 1')
 
     // Add header only to f1
     f1.addHeaders({
       'accept': 'application/json'
-    });
+    })
 
     // verify that the header is set correctly
     expect(f1.current.request.headers).to.deep.equal({
       'accept': 'application/json'
-    });
+    })
 
     // Add a new accept header
     f1.addHeaders({
       'accept': 'json'
-    });
+    })
 
     // verify that there is only one header
     expect(f1.current.request.headers).to.deep.equal({
       'accept': 'json'
-    });
-  });
+    })
+  })
 
   it('should default to json = false', function() {
     expect(frisby.globalSetup()).to.deep.equal({
@@ -120,10 +120,10 @@ describe('Frisby object setup', function() {
         json: false,
         baseUri: ''
       }
-    });
+    })
 
-    expect(frisby.create('mytest').get('/path').current.outgoing.json).to.deep.equal(false);
-  });
+    expect(frisby.create('mytest').get('/path').current.outgoing.json).to.deep.equal(false)
+  })
 
   it('should switch to json default = true when global config is configured json', function() {
     frisby.globalSetup({
@@ -132,7 +132,7 @@ describe('Frisby object setup', function() {
         inspectOnFailure: false,
         json: true
       }
-    });
+    })
 
     expect(frisby.globalSetup()).to.deep.equal({
       request: {
@@ -141,37 +141,37 @@ describe('Frisby object setup', function() {
         inspectOnFailure: false,
         json: true
       }
-    });
+    })
 
-    expect(frisby.create('mytest').get('/path').current.outgoing.json).to.deep.equal(true);
-  });
+    expect(frisby.create('mytest').get('/path').current.outgoing.json).to.deep.equal(true)
+  })
 
   it('should be able to reset the request object with reset()', function() {
-      frisby.globalSetup({
-          request: {
-              headers: { 'X-Stuff': 'stuff header' },
-              json: true,
-              baseUri: 'https://some.base.url.com/'
-          }
-      });
+    frisby.globalSetup({
+      request: {
+        headers: { 'X-Stuff': 'stuff header' },
+        json: true,
+        baseUri: 'https://some.base.url.com/'
+      }
+    })
 
       // verify that the global config was set properly
-      expect(frisby.globalSetup()).to.deep.equal({
-          request: {
-              headers: { 'X-Stuff': 'stuff header' },
-              json: true,
-              baseUri: 'https://some.base.url.com/',
-              inspectOnFailure: false
-          }
-      });
+    expect(frisby.globalSetup()).to.deep.equal({
+      request: {
+        headers: { 'X-Stuff': 'stuff header' },
+        json: true,
+        baseUri: 'https://some.base.url.com/',
+        inspectOnFailure: false
+      }
+    })
 
-      expect(frisby.create('mytest').reset().current.request).to.deep.equal({
-        baseUri: "",
-        headers: {},
-        inspectOnFailure: false,
-        json: false
-      });
-  });
+    expect(frisby.create('mytest').reset().current.request).to.deep.equal({
+      baseUri: "",
+      headers: {},
+      inspectOnFailure: false,
+      json: false
+    })
+  })
 
   it('should be overridable by the params parameter json=false', function() {
     frisby.globalSetup({
@@ -180,7 +180,7 @@ describe('Frisby object setup', function() {
         inspectOnFailure: false,
         json: true
       }
-    });
+    })
 
     expect(frisby.globalSetup()).to.deep.equal({
       request: {
@@ -189,12 +189,12 @@ describe('Frisby object setup', function() {
         inspectOnFailure: false,
         json: true
       }
-    });
+    })
 
     expect(frisby.create('mytest').get('/path', {
       json: false
-    }).current.outgoing.json).to.equal(false);
-  });
+    }).current.outgoing.json).to.equal(false)
+  })
 
   it('should switch to inspectOnFailure default = true when global config is configured inspectOnFailure', function() {
     frisby.globalSetup({
@@ -203,7 +203,7 @@ describe('Frisby object setup', function() {
         inspectOnFailure: true,
         json: false
       }
-    });
+    })
 
     expect(frisby.globalSetup()).to.deep.equal({
       request: {
@@ -212,10 +212,10 @@ describe('Frisby object setup', function() {
         inspectOnFailure: true,
         json: false
       }
-    });
+    })
 
-    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailure).to.deep.equal(true);
-  });
+    expect(frisby.create('mytest').get('/path').current.outgoing.inspectOnFailure).to.deep.equal(true)
+  })
 
   it('should be overridable by the params parameter inspectOnFailure=false', function() {
     frisby.globalSetup({
@@ -224,7 +224,7 @@ describe('Frisby object setup', function() {
         inspectOnFailure: true,
         json: false
       }
-    });
+    })
 
     expect({
       request: {
@@ -233,11 +233,11 @@ describe('Frisby object setup', function() {
         inspectOnFailure: true,
         json: false
       }
-    }).to.deep.equal(frisby.globalSetup());
+    }).to.deep.equal(frisby.globalSetup())
 
     expect(frisby.create('mytest').get('/path', {
       inspectOnFailure: false
-    }).current.outgoing.inspectOnFailure).to.equal(false);
-  });
+    }).current.outgoing.inspectOnFailure).to.equal(false)
+  })
 
-});
+})

--- a/test/frisby_httpbin.js
+++ b/test/frisby_httpbin.js
@@ -1,25 +1,25 @@
-'use strict';
+'use strict'
 
-var frisby = require('../lib/icedfrisby');
-var Joi = require('joi');
-var fs = require('fs');
-var path = require('path');
-var util = require('util');
-var Readable = require('stream').Readable;
+var frisby = require('../lib/icedfrisby')
+var Joi = require('joi')
+var fs = require('fs')
+var path = require('path')
+var util = require('util')
+var Readable = require('stream').Readable
 
 function StringStream(string, options) {
-    Readable.call(this, options);
+  Readable.call(this, options)
 
-    this.writable = false;
-    this.readable = true;
-    this.string = string;
+  this.writable = false
+  this.readable = true
+  this.string = string
 }
-util.inherits(StringStream, Readable);
+util.inherits(StringStream, Readable)
 
 StringStream.prototype._read = function (ignore) {
-    this.push(this.string);
-    this.push(null);
-};
+  this.push(this.string)
+  this.push(null)
+}
 
 //
 // Tests run like normal Frisby specs but with 'mock' specified with a 'mock-request' object
@@ -33,9 +33,9 @@ describe('Frisby live running httpbin tests', function() {
       .get('http://httpbin.org/basic-auth/frisby/passwd')
       .auth('frisby', 'passwd')
       .expectStatus(200)
-    .toss();
+    .toss()
 
-  });
+  })
 
   describe('Frisby digestAuth', function() {
 
@@ -45,9 +45,9 @@ describe('Frisby live running httpbin tests', function() {
         .auth('frisby', 'passwd')
         .get('http://httpbin.org/digest-auth/auth/frisby/passwd')
         .expectStatus(401)
-      .toss();
+      .toss()
 
-    });
+    })
 
 
     /*
@@ -62,157 +62,157 @@ describe('Frisby live running httpbin tests', function() {
     });
     */
 
-  });
+  })
 
   it('should pass in param hash to request call dependency', function() {
 
     frisby.create('test with httpbin for valid basic auth')
       .get('http://httpbin.org/redirect/3', { followRedirect: false, maxRedirects: 1 })
       .expectStatus(302)
-    .toss();
+    .toss()
 
-  });
+  })
   //
   it('sending binary data via put or post requests using Buffer objects should work', function() {
 
-      var data = [];
+    var data = []
 
-      for(var i=0; i< 1024; i++)
-        data.push(Math.round(Math.random()*256));
+    for(var i=0; i< 1024; i++)
+      data.push(Math.round(Math.random()*256))
 
 
-      frisby.create('POST random binary data via Buffer object')
+    frisby.create('POST random binary data via Buffer object')
         .post('http://httpbin.org/post',
               new Buffer(data),
-              {
-                  json : false,
-                  headers : {
-                      "content-type" : "application/octet-stream"
-                  }
-              })
+      {
+        json : false,
+        headers : {
+          "content-type" : "application/octet-stream"
+        }
+      })
           .expectStatus(200)
           .expectHeaderContains('content-type', 'application/json')
           .expectJSONTypes({ // use the JSONTypes to check for data and headers. We don't really care about anything else.
-              data : Joi.string().valid('data:application/octet-stream;base64,'+ new Buffer(data).toString('base64')),
-              headers: Joi.object().required().keys({
-                  Accept: Joi.any(),
-                  "Accept-Encoding": Joi.any(),
-                  Connection: Joi.any(),
-                  "Content-Type": Joi.string().required().valid("application/octet-stream"),
-                  "Content-Length" : Joi.string().required().valid("1024"),
-                  Host: Joi.any()
-              }),
-              args: Joi.any(),
-              files: Joi.any(),
-              form: Joi.any(),
-              json: Joi.any(),
-              origin: Joi.any(),
-              url: Joi.string().required().valid("http://httpbin.org/post")
+            data : Joi.string().valid('data:application/octet-stream;base64,'+ new Buffer(data).toString('base64')),
+            headers: Joi.object().required().keys({
+              Accept: Joi.any(),
+              "Accept-Encoding": Joi.any(),
+              Connection: Joi.any(),
+              "Content-Type": Joi.string().required().valid("application/octet-stream"),
+              "Content-Length" : Joi.string().required().valid("1024"),
+              Host: Joi.any()
+            }),
+            args: Joi.any(),
+            files: Joi.any(),
+            form: Joi.any(),
+            json: Joi.any(),
+            origin: Joi.any(),
+            url: Joi.string().required().valid("http://httpbin.org/post")
           })
-      .toss();
+      .toss()
 
-      frisby.create('PUT random binary data via Buffer object')
+    frisby.create('PUT random binary data via Buffer object')
         .put('http://httpbin.org/put',
               new Buffer(data),
-              {
-                  json : false,
-                  headers : {
-                      "content-type" : "application/octet-stream"
-                  }
-              })
+      {
+        json : false,
+        headers : {
+          "content-type" : "application/octet-stream"
+        }
+      })
           .expectStatus(200)
           .expectHeaderContains('content-type', 'application/json')
           .expectJSONTypes({
-              data : Joi.string().required().valid('data:application/octet-stream;base64,'+ new Buffer(data).toString('base64')),
-              headers: Joi.object().keys({
-                  Accept: Joi.any(),
-                  "Accept-Encoding": Joi.any(),
-                  Connection: Joi.any(),
-                  "Content-Type": Joi.string().required().valid("application/octet-stream"),
-                  "Content-Length" : Joi.string().required().valid("1024"),
-                  Host: Joi.any()
-              }),
-              args: Joi.any(),
-              files: Joi.any(),
-              form: Joi.any(),
-              json: Joi.any(),
-              origin: Joi.any(),
-              url: Joi.string().required().valid("http://httpbin.org/put")
+            data : Joi.string().required().valid('data:application/octet-stream;base64,'+ new Buffer(data).toString('base64')),
+            headers: Joi.object().keys({
+              Accept: Joi.any(),
+              "Accept-Encoding": Joi.any(),
+              Connection: Joi.any(),
+              "Content-Type": Joi.string().required().valid("application/octet-stream"),
+              "Content-Length" : Joi.string().required().valid("1024"),
+              Host: Joi.any()
+            }),
+            args: Joi.any(),
+            files: Joi.any(),
+            form: Joi.any(),
+            json: Joi.any(),
+            origin: Joi.any(),
+            url: Joi.string().required().valid("http://httpbin.org/put")
           })
-      .toss();
+      .toss()
 
-  });
+  })
   //
   it('PATCH requests with Buffer and Stream objects should work.', function() {
-      var patchCommand = 'Patch me!';
+    var patchCommand = 'Patch me!'
 
-      frisby.create('PATCH via Buffer object')
+    frisby.create('PATCH via Buffer object')
           .patch('http://httpbin.org/patch',
           new Buffer(patchCommand),
-          {
-              json : false,
-              headers : {
-                  "content-type" : "text/plain"
-              }
-          })
+      {
+        json : false,
+        headers : {
+          "content-type" : "text/plain"
+        }
+      })
           .expectStatus(200)
           .expectHeaderContains('content-type', 'application/json')
           .expectJSONTypes({
-              data : Joi.string().valid(patchCommand.toString()),
-              headers: Joi.object().required().keys({
-                  Accept: Joi.any(),
-                  "Accept-Encoding": Joi.any(),
-                  Connection: Joi.any(),
-                  "Content-Type": Joi.string().required().valid("text/plain"),
-                  "Content-Length" : Joi.string().required().valid("" + patchCommand.length),
-                  Host: Joi.any()
-              }),
-              args: Joi.any(),
-              files: Joi.any(),
-              form: Joi.any(),
-              json: Joi.any(),
-              origin: Joi.any(),
-              url: Joi.string().required().valid("http://httpbin.org/patch")
+            data : Joi.string().valid(patchCommand.toString()),
+            headers: Joi.object().required().keys({
+              Accept: Joi.any(),
+              "Accept-Encoding": Joi.any(),
+              Connection: Joi.any(),
+              "Content-Type": Joi.string().required().valid("text/plain"),
+              "Content-Length" : Joi.string().required().valid("" + patchCommand.length),
+              Host: Joi.any()
+            }),
+            args: Joi.any(),
+            files: Joi.any(),
+            form: Joi.any(),
+            json: Joi.any(),
+            origin: Joi.any(),
+            url: Joi.string().required().valid("http://httpbin.org/patch")
           })
-          .toss();
+          .toss()
 
-      frisby.create('PATCH via Stream object')
+    frisby.create('PATCH via Stream object')
           .patch('http://httpbin.org/patch',
           new StringStream(patchCommand),
-          {
-              json : false,
-              headers : {
-                  "content-type" : "text/plain",
-                  "content-length" : String(patchCommand.length)
-              }
-          })
+      {
+        json : false,
+        headers : {
+          "content-type" : "text/plain",
+          "content-length" : String(patchCommand.length)
+        }
+      })
           .expectStatus(200)
           .expectHeaderContains('content-type', 'application/json')
           .expectJSONTypes({
-              data : Joi.string().required().valid(patchCommand.toString()),
-              headers: Joi.object().required().keys({
-                  Accept: Joi.any(),
-                  "Accept-Encoding": Joi.any(),
-                  Connection: Joi.any(),
-                  "Content-Type": Joi.string().required().valid("text/plain"),
-                  "Content-Length" : Joi.string().required().valid("" + patchCommand.length),
-                  Host: Joi.any()
-              }),
-              args: Joi.any(),
-              files: Joi.any(),
-              form: Joi.any(),
-              json: Joi.any(),
-              origin: Joi.any(),
-              url: Joi.string().required().valid("http://httpbin.org/patch")
+            data : Joi.string().required().valid(patchCommand.toString()),
+            headers: Joi.object().required().keys({
+              Accept: Joi.any(),
+              "Accept-Encoding": Joi.any(),
+              Connection: Joi.any(),
+              "Content-Type": Joi.string().required().valid("text/plain"),
+              "Content-Length" : Joi.string().required().valid("" + patchCommand.length),
+              Host: Joi.any()
+            }),
+            args: Joi.any(),
+            files: Joi.any(),
+            form: Joi.any(),
+            json: Joi.any(),
+            origin: Joi.any(),
+            url: Joi.string().required().valid("http://httpbin.org/patch")
           })
-          .toss();
+          .toss()
 
-  });
+  })
 
   it('sending binary data via put or post requests using Stream objects should work', function() {
-        var filePath = path.resolve(__dirname, './logo-frisby.png');
-        var fileSize = fs.statSync(filePath).size;
-        var fileContent = fs.readFileSync(filePath);
+    var filePath = path.resolve(__dirname, './logo-frisby.png')
+    var fileSize = fs.statSync(filePath).size
+    var fileContent = fs.readFileSync(filePath)
 
         /*
          * NOTE: Using a Stream with httpbin.org requires to set the Content-Length header to not use chunked
@@ -220,68 +220,68 @@ describe('Frisby live running httpbin tests', function() {
          *       Content-Length
          */
 
-        frisby.create('POST frisby logo to http://httpbin.org/post using a Stream')
+    frisby.create('POST frisby logo to http://httpbin.org/post using a Stream')
             .post('http://httpbin.org/post',
                 fs.createReadStream(filePath),
-                {
-                    json: false,
-                    headers: {
-                        "content-type": "application/octet-stream",
-                        "content-length": fileSize
-                    }
-                })
+      {
+        json: false,
+        headers: {
+          "content-type": "application/octet-stream",
+          "content-length": fileSize
+        }
+      })
                 .expectStatus(200)
                 .expectHeaderContains('content-type', 'application/json')
                 .expectJSONTypes({
-                    data : Joi.string().required().valid('data:application/octet-stream;base64,' + fileContent.toString('base64')),
-                    headers: Joi.object().required().keys({
-                        Accept: Joi.any(),
-                        "Accept-Encoding": Joi.any(),
-                        Connection: Joi.any(),
-                        "Content-Type": Joi.string().valid("application/octet-stream"),
-                        "Content-Length" : Joi.string().valid("" + fileSize),
-                        Host: Joi.any()
-                    }),
-                    args: Joi.any(),
-                    files: Joi.any(),
-                    form: Joi.any(),
-                    json: Joi.any(),
-                    origin: Joi.any(),
-                    url: Joi.string().required().valid("http://httpbin.org/post"),
+                  data : Joi.string().required().valid('data:application/octet-stream;base64,' + fileContent.toString('base64')),
+                  headers: Joi.object().required().keys({
+                    Accept: Joi.any(),
+                    "Accept-Encoding": Joi.any(),
+                    Connection: Joi.any(),
+                    "Content-Type": Joi.string().valid("application/octet-stream"),
+                    "Content-Length" : Joi.string().valid("" + fileSize),
+                    Host: Joi.any()
+                  }),
+                  args: Joi.any(),
+                  files: Joi.any(),
+                  form: Joi.any(),
+                  json: Joi.any(),
+                  origin: Joi.any(),
+                  url: Joi.string().required().valid("http://httpbin.org/post"),
                 })
-                .toss();
+                .toss()
 
-        frisby.create('PUT frisby logo to http://httpbin.org/put using a Stream')
+    frisby.create('PUT frisby logo to http://httpbin.org/put using a Stream')
             .put('http://httpbin.org/put',
                 fs.createReadStream(filePath),
-                {
-                    json: false,
-                    headers: {
-                        "Content-Type": "application/octet-stream",
-                        "Content-Length": fileSize
-                    }
-                })
+      {
+        json: false,
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "Content-Length": fileSize
+        }
+      })
                 .expectStatus(200)
                 .expectHeaderContains('content-type', 'application/json')
                 .expectJSONTypes({
-                    data : Joi.string().valid('data:application/octet-stream;base64,' + fileContent.toString('base64')),
-                    headers: Joi.object().keys({
-                        Accept: Joi.any(),
-                        "Accept-Encoding": Joi.any(),
-                        Connection: Joi.any(),
-                        "Content-Type": Joi.string().valid("application/octet-stream"),
-                        "Content-Length" : Joi.string().valid("" + fileSize),
-                        Host: Joi.any()
-                    }),
-                    args: Joi.any(),
-                    files: Joi.any(),
-                    form: Joi.any(),
-                    json: Joi.any(),
-                    origin: Joi.any(),
-                    url: Joi.string().valid("http://httpbin.org/put"),
+                  data : Joi.string().valid('data:application/octet-stream;base64,' + fileContent.toString('base64')),
+                  headers: Joi.object().keys({
+                    Accept: Joi.any(),
+                    "Accept-Encoding": Joi.any(),
+                    Connection: Joi.any(),
+                    "Content-Type": Joi.string().valid("application/octet-stream"),
+                    "Content-Length" : Joi.string().valid("" + fileSize),
+                    Host: Joi.any()
+                  }),
+                  args: Joi.any(),
+                  files: Joi.any(),
+                  form: Joi.any(),
+                  json: Joi.any(),
+                  origin: Joi.any(),
+                  url: Joi.string().valid("http://httpbin.org/put"),
                 })
-                .toss();
-    });
+                .toss()
+  })
 
   // it('sending multipart/from-data encoded bodies should work', function () {
   //
@@ -446,4 +446,4 @@ describe('Frisby live running httpbin tests', function() {
   //     .toss();
   //
   // })
-});
+})

--- a/test/frisby_inspect.js
+++ b/test/frisby_inspect.js
@@ -1,190 +1,190 @@
-'use strict';
+'use strict'
 
-var frisby = require('../lib/icedfrisby');
-var expect = require('chai').expect;
-var nock = require('nock');
+var frisby = require('../lib/icedfrisby')
+var expect = require('chai').expect
+var nock = require('nock')
 
 describe('IcedFrisby inspect methods', function() {
 
-    it('should perform no action if null is provided to the inspect() callback', function() {
-        var inspectNock = nock('http://inspect-null.httpbin.org')
+  it('should perform no action if null is provided to the inspect() callback', function() {
+    var inspectNock = nock('http://inspect-null.httpbin.org')
             .get('/get')
             .once()
             .reply(200, {
-                "args": {},
-                "headers": {
-                    "Host": "httpbin.org",
-                },
-                "origin": "127.0.0.1",
-                "url": "http://inspect.httpbin.org/get"
-            });
+              "args": {},
+              "headers": {
+                "Host": "httpbin.org",
+              },
+              "origin": "127.0.0.1",
+              "url": "http://inspect.httpbin.org/get"
+            })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .get('http://inspect-null.httpbin.org/get', {json: true})
             .inspect(null)
             .after(function() {
                 // check that the mock was consumed
-                inspectNock.done();
+              inspectNock.done()
             })
-            .toss();
-    });
+            .toss()
+  })
 
-    it('should allow a call to inspect the request and response', function() {
-        var inspectNock = nock('http://inspect.httpbin.org')
+  it('should allow a call to inspect the request and response', function() {
+    var inspectNock = nock('http://inspect.httpbin.org')
             .get('/get')
             .reply(200, {
-                "args": {},
-                "headers": {
-                    "Host": "httpbin.org",
-                },
-                "origin": "127.0.0.1",
-                "url": "http://inspect.httpbin.org/get"
-            });
+              "args": {},
+              "headers": {
+                "Host": "httpbin.org",
+              },
+              "origin": "127.0.0.1",
+              "url": "http://inspect.httpbin.org/get"
+            })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .get('http://inspect.httpbin.org/get', {json: true})
             .inspect(function(err, req, res, body, headers) {
-                expect(err).to.equal(null);
-                expect(req).to.be.an('object');
-                expect(res).to.be.an('object');
-                expect(body).to.be.an('object');
-                expect(headers).to.be.an('object');
+              expect(err).to.equal(null)
+              expect(req).to.be.an('object')
+              expect(res).to.be.an('object')
+              expect(body).to.be.an('object')
+              expect(headers).to.be.an('object')
 
                 // check that the mock was consumed
-                inspectNock.done();
+              inspectNock.done()
             })
-            .toss();
-    });
+            .toss()
+  })
 
-    it('- inspectRequest should work', function() {
-        var inspectNock = nock('http://inspectRequest.httpbin.org')
+  it('- inspectRequest should work', function() {
+    var inspectNock = nock('http://inspectRequest.httpbin.org')
             .get('/get')
             .reply(200, {
-                "args": {},
-                "headers": {
-                    "Host": "httpbin.org",
-                },
-                "origin": "127.0.0.1",
-                "url": "http://inspect.httpbin.org/get"
-            });
+              "args": {},
+              "headers": {
+                "Host": "httpbin.org",
+              },
+              "origin": "127.0.0.1",
+              "url": "http://inspect.httpbin.org/get"
+            })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .get('http://inspectRequest.httpbin.org/get', {json: true})
             .inspectRequest('inspectRequest')
             .after(function() {
                 // check that the mock was consumed
-                inspectNock.done();
+              inspectNock.done()
             })
-            .toss();
-    });
+            .toss()
+  })
 
-    it('- inspectResponse should work', function() {
-        var inspectNock = nock('http://inspectResponse.httpbin.org')
+  it('- inspectResponse should work', function() {
+    var inspectNock = nock('http://inspectResponse.httpbin.org')
             .get('/get')
             .reply(200, {
-                "args": {},
-                "headers": {
-                    "Host": "httpbin.org",
-                },
-                "origin": "127.0.0.1",
-                "url": "http://inspect.httpbin.org/get"
-            });
+              "args": {},
+              "headers": {
+                "Host": "httpbin.org",
+              },
+              "origin": "127.0.0.1",
+              "url": "http://inspect.httpbin.org/get"
+            })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .get('http://inspectResponse.httpbin.org/get', {json: true})
             .inspectResponse('inspectResponse')
             .after(function() {
                 // check that the mock was consumed
-                inspectNock.done();
+              inspectNock.done()
             })
-            .toss();
-    });
+            .toss()
+  })
 
-    it('- inspectHeaders should work', function() {
-        var inspectNock = nock('http://inspectHeaders.httpbin.org')
+  it('- inspectHeaders should work', function() {
+    var inspectNock = nock('http://inspectHeaders.httpbin.org')
             .get('/get')
             .reply(200, {
-                "args": {},
-                "headers": {
-                    "Host": "httpbin.org",
-                },
-                "origin": "127.0.0.1",
-                "url": "http://inspect.httpbin.org/get"
-            });
+              "args": {},
+              "headers": {
+                "Host": "httpbin.org",
+              },
+              "origin": "127.0.0.1",
+              "url": "http://inspect.httpbin.org/get"
+            })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .get('http://inspectHeaders.httpbin.org/get', {json: true})
             .inspectHeaders('inspectHeaders')
             .after(function() {
                 // check that the mock was consumed
-                inspectNock.done();
+              inspectNock.done()
             })
-            .toss();
-    });
+            .toss()
+  })
 
-    it('- inspectBody should work', function() {
-        var inspectNock = nock('http://inspectBody.httpbin.org')
+  it('- inspectBody should work', function() {
+    var inspectNock = nock('http://inspectBody.httpbin.org')
             .get('/get')
             .reply(200, {
-                "args": {},
-                "headers": {
-                    "Host": "httpbin.org",
-                },
-                "origin": "127.0.0.1",
-                "url": "http://inspect.httpbin.org/get"
-            });
+              "args": {},
+              "headers": {
+                "Host": "httpbin.org",
+              },
+              "origin": "127.0.0.1",
+              "url": "http://inspect.httpbin.org/get"
+            })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .get('http://inspectBody.httpbin.org/get', {json: true})
             .inspectBody('inspectBody')
             .after(function() {
                 // check that the mock was consumed
-                inspectNock.done();
+              inspectNock.done()
             })
-            .toss();
-    });
+            .toss()
+  })
 
-    it('- inspectJSON should work', function() {
-        var inspectNock = nock('http://inspectJSON.httpbin.org')
+  it('- inspectJSON should work', function() {
+    var inspectNock = nock('http://inspectJSON.httpbin.org')
             .get('/get')
             .reply(200, {
-                "args": {},
-                "headers": {
-                    "Host": "httpbin.org",
-                },
-                "origin": "127.0.0.1",
-                "url": "http://inspect.httpbin.org/get"
-            });
+              "args": {},
+              "headers": {
+                "Host": "httpbin.org",
+              },
+              "origin": "127.0.0.1",
+              "url": "http://inspect.httpbin.org/get"
+            })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .get('http://inspectJSON.httpbin.org/get', {json: true})
             .inspectJSON('inspectJSON')
             .after(function() {
                 // check that the mock was consumed
-                inspectNock.done();
+              inspectNock.done()
             })
-            .toss();
-    });
+            .toss()
+  })
 
-    it('- inspectStatus should work', function() {
-        var inspectNock = nock('http://inspectStatus.httpbin.org')
+  it('- inspectStatus should work', function() {
+    var inspectNock = nock('http://inspectStatus.httpbin.org')
             .get('/get')
             .reply(200, {
-                "args": {},
-                "headers": {
-                    "Host": "httpbin.org",
-                },
-                "origin": "127.0.0.1",
-                "url": "http://inspect.httpbin.org/get"
-            });
+              "args": {},
+              "headers": {
+                "Host": "httpbin.org",
+              },
+              "origin": "127.0.0.1",
+              "url": "http://inspect.httpbin.org/get"
+            })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .get('http://inspectStatus.httpbin.org/get', {json: true})
             .inspectStatus('inspectStatus')
             .after(function() {
                 // check that the mock was consumed
-                inspectNock.done();
+              inspectNock.done()
             })
-            .toss();
-    });
-});
+            .toss()
+  })
+})

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -1,20 +1,20 @@
-'use strict';
+'use strict'
 
-var nock = require('nock');
-var fixtures = require('./fixtures/repetition_fixture.json');
-var frisby = require('../lib/icedfrisby');
-var mockRequest = require('mock-request');
-var Joi = require('joi');
-const AssertionError = require('chai').AssertionError;
-const MultiError = require('verror').MultiError;
+var nock = require('nock')
+var fixtures = require('./fixtures/repetition_fixture.json')
+var frisby = require('../lib/icedfrisby')
+var mockRequest = require('mock-request')
+var Joi = require('joi')
+const AssertionError = require('chai').AssertionError
+const MultiError = require('verror').MultiError
 
 // Built-in node.js
-var fs = require('fs');
-var path = require('path');
-const util = require('util');
+var fs = require('fs')
+var path = require('path')
+const util = require('util')
 
 // enable real connections for localhost otherwise useApp() tests won't work
-nock.enableNetConnect('127.0.0.1');
+nock.enableNetConnect('127.0.0.1')
 
 // Test global setup
 
@@ -27,8 +27,8 @@ var mockGlobalSetup = function() {
         'Referer': 'http://frisbyjs.com'
       }
     }
-  });
-};
+  })
+}
 
 var restoreGlobalSetup = function() {
   frisby.globalSetup({
@@ -38,8 +38,8 @@ var restoreGlobalSetup = function() {
       json: false,
       baseUri: ''
     }
-  });
-};
+  })
+}
 
 //
 // Tests run like normal Frisby specs but with 'mock' specified with a 'mock-request' object
@@ -54,20 +54,20 @@ describe('Frisby matchers', function() {
       .respond({
         statusCode: 404
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/not-found', {mock: mockFn})
       .expectStatus(404)
-      .toss();
-  });
+      .toss()
+  })
 
   it('globalSetup should set timeout to 3000', function() {
-    mockGlobalSetup();
-    var f1 = frisby.create(this.test.title);
-    expect(f1.timeout()).to.equal(3000);
-    restoreGlobalSetup();
-  });
+    mockGlobalSetup()
+    var f1 = frisby.create(this.test.title)
+    expect(f1.timeout()).to.equal(3000)
+    restoreGlobalSetup()
+  })
 
   it('globalSetup should set local request headers', function() {
     // Mock API
@@ -77,18 +77,18 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
-    mockGlobalSetup();
+    mockGlobalSetup()
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .after(function(err, res, body) {
-        expect(this.current.outgoing.headers['test']).to.equal('One');
-        expect(this.current.outgoing.headers['referer']).to.equal('http://frisbyjs.com');
+        expect(this.current.outgoing.headers['test']).to.equal('One')
+        expect(this.current.outgoing.headers['referer']).to.equal('http://frisbyjs.com')
       })
-      .toss();
-    restoreGlobalSetup();
-  });
+      .toss()
+    restoreGlobalSetup()
+  })
 
   it('addHeaders should override globalSetup request headers', function() {
     // Mock API
@@ -98,19 +98,19 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
-    mockGlobalSetup();
+    mockGlobalSetup()
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .addHeaders({ 'Test': 'Two' })
       .after(function(err, res, body) {
         // Local addHeaders should override global
-        expect(this.current.outgoing.headers['test']).to.equal('Two');
+        expect(this.current.outgoing.headers['test']).to.equal('Two')
       })
-      .toss();
-    restoreGlobalSetup();
-  });
+      .toss()
+    restoreGlobalSetup()
+  })
 
   it('addHeaders should override globalSetup request headers and not taint other Frisby tests', function() {
     // Mock API
@@ -120,159 +120,159 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
     var mockFn2 = mockRequest.mock()
     .get('/test-object-array-ex2')
       .respond({
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
-    mockGlobalSetup();
+    mockGlobalSetup()
 
     frisby.create(this.test.title + ' - mock test one')
       .get('http://mock-request/test-object-array-ex', {mock: mockFn})
       .addHeaders({ 'Test': 'Two' })
       .after(function(err, res, body) {
         // Local addHeaders should override global
-        expect(this.current.outgoing.headers['test']).to.equal('Two');
+        expect(this.current.outgoing.headers['test']).to.equal('Two')
       })
-    .toss();
+    .toss()
 
     frisby.create(this.test.title + ' - mock test two')
       .get('http://mock-request/test-object-array-ex2', {mock: mockFn2})
       .addHeaders({ 'Test': 'Three' })
       .after(function(err, res, body) {
         // Local addHeaders should override global
-        expect(this.current.outgoing.headers['test']).to.equal('Three');
+        expect(this.current.outgoing.headers['test']).to.equal('Three')
       })
-    .toss();
+    .toss()
 
-    restoreGlobalSetup();
-  });
+    restoreGlobalSetup()
+  })
 
   describe('before callbacks', function () {
     it('should be invoked in sequence before the request', function() {
-      const sequence = [];
+      const sequence = []
 
       const mockFn = mockRequest.mock()
         .get('/test-object')
         .respond({
-            statusCode: 200,
-            body: fixtures.singleObject
+          statusCode: 200,
+          body: fixtures.singleObject
         })
-        .run();
+        .run()
       const requestFn = function () {
-        sequence.push('request');
-        return mockFn.apply(this, arguments);
-      };
+        sequence.push('request')
+        return mockFn.apply(this, arguments)
+      }
 
       frisby.create(this.test.title)
-        .before(() => { sequence.push('before-one'); })
-        .before(() => { sequence.push('before-two'); })
+        .before(() => { sequence.push('before-one') })
+        .before(() => { sequence.push('before-two') })
         .get('http://mock-request/test-object', {mock: requestFn})
         .after(() => {
-          const expectedSequence = ['before-one', 'before-two', 'request'];
-          expect(sequence).to.deep.equal(expectedSequence);
+          const expectedSequence = ['before-one', 'before-two', 'request']
+          expect(sequence).to.deep.equal(expectedSequence)
         })
-        .toss();
-    });
+        .toss()
+    })
 
     it('should respect the exception handler', function() {
       const mockFn = mockRequest.mock()
         .get('/test-object')
         .respond({
-            statusCode: 200,
-            body: fixtures.singleObject
+          statusCode: 200,
+          body: fixtures.singleObject
         })
-        .run();
+        .run()
 
-      const message = 'this is the error';
+      const message = 'this is the error'
 
       frisby.create(this.test.title)
-        .before(() => { throw new Error(message); })
+        .before(() => { throw new Error(message) })
         .get('http://mock-request/test-object', {mock: mockFn})
         .exceptionHandler(err => {
-          expect(err.message).to.equal(message);
+          expect(err.message).to.equal(message)
         })
-        .toss();
-    });
-  });
+        .toss()
+    })
+  })
 
   it('expectJSON should test EQUALITY for a SINGLE object', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-object')
       .respond({
-          statusCode: 200,
-          body: fixtures.singleObject
+        statusCode: 200,
+        body: fixtures.singleObject
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object', {mock: mockFn})
       .expectJSON({
-          test_str: "Hey Hai Hello",
-          test_str_same: "I am the same...",
-          test_int: 1,
-          test_optional: null
+        test_str: "Hey Hai Hello",
+        test_str_same: "I am the same...",
+        test_int: 1,
+        test_optional: null
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSON should test INEQUALITY for a SINGLE object', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-object')
       .respond({
-          statusCode: 200,
-          body: fixtures.singleObject
+        statusCode: 200,
+        body: fixtures.singleObject
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object', {mock: mockFn})
       .not().expectJSON({
-          test_str: "Bye bye bye!",
-          test_str_same: "I am not the same...",
-          test_int: 9,
-          test_optional: true
+        test_str: "Bye bye bye!",
+        test_str_same: "I am not the same...",
+        test_int: 9,
+        test_optional: true
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSON should test EQUALITY for EACH object in an array with an asterisk path', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-array')
       .respond({
-          statusCode: 200,
-          body: fixtures.sameNumbers
+        statusCode: 200,
+        body: fixtures.sameNumbers
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-array', {mock: mockFn})
       .expectJSON('*', { num: 5 })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSON should test INEQUALITY for EACH object in an array with an asterisk path', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-array')
       .respond({
-          statusCode: 200,
-          body: fixtures.sameNumbers
+        statusCode: 200,
+        body: fixtures.sameNumbers
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-array', {mock: mockFn})
       .not().expectJSON('*', { num: 123 })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSON should test EACH object in an array with path ending with asterisk', function() {
     // Mock API
@@ -282,7 +282,7 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
@@ -292,8 +292,8 @@ describe('Frisby matchers', function() {
         test_str: Joi.string(),
         test_optional: Joi.any().optional()
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSON should match ONE object in an array with path ending with question mark', function() {
     // Mock API
@@ -303,7 +303,7 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
@@ -313,8 +313,8 @@ describe('Frisby matchers', function() {
         test_str: Joi.string().valid("I am a string two!"),
         test_optional: Joi.any().optional()
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSON should NOT match ONE object in an array with path ending with question mark', function() {
     // Mock API
@@ -324,7 +324,7 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
@@ -332,157 +332,157 @@ describe('Frisby matchers', function() {
         test_str: "I am a string two nonsense!",
         test_int: 4433
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectContainsJSON should MATCH fields for a SINGLE object', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-object')
       .respond({
-          statusCode: 200,
-          body: fixtures.singleObject
+        statusCode: 200,
+        body: fixtures.singleObject
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object', {mock: mockFn})
       .expectContainsJSON({
-          test_str: "Hey Hai Hello",
+        test_str: "Hey Hai Hello",
           // test_str_same: "I am the same...", // leave this out of the orig object, should still match
-          test_int: 1,
-          test_optional: null
+        test_int: 1,
+        test_optional: null
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectContainsJSON should NOT MATCH for a SINGLE object', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-object')
       .respond({
-          statusCode: 200,
-          body: fixtures.singleObject
+        statusCode: 200,
+        body: fixtures.singleObject
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object', {mock: mockFn})
       .not().expectContainsJSON({
-          test_str: "Bye bye bye!",
-          test_str_same: "I am not the same...",
-          test_int: 9,
-          test_optional: true
+        test_str: "Bye bye bye!",
+        test_str_same: "I am not the same...",
+        test_int: 9,
+        test_optional: true
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectContainsJSON should NOT MATCH for a SINGLE object with a single field', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-object')
       .respond({
-          statusCode: 200,
-          body: fixtures.singleObject
+        statusCode: 200,
+        body: fixtures.singleObject
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object', {mock: mockFn})
       .not().expectContainsJSON({
-          test_str: "Bye bye bye!",
+        test_str: "Bye bye bye!",
           // test_str_same: "I am not the same...",
           // test_int: 9,
           // test_optional: true
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectContainsJSON should MATCH for EACH object in an array with an asterisk path', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-array')
       .respond({
-          statusCode: 200,
-          body: fixtures.sameNumbers
+        statusCode: 200,
+        body: fixtures.sameNumbers
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-array', {mock: mockFn})
       .expectContainsJSON('*', { num: 5 })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectContainsJSON should NOT MATCH for EACH object in an array with an asterisk path', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-array')
       .respond({
-          statusCode: 200,
-          body: fixtures.sameNumbers
+        statusCode: 200,
+        body: fixtures.sameNumbers
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-array', {mock: mockFn})
       .not().expectContainsJSON('*', { num: 123 })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectContainsJSON should MATCH for EACH object in an array with path ending with asterisk', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-object-array')
       .respond({
-          statusCode: 200,
-          body: fixtures.arrayOfObjects
+        statusCode: 200,
+        body: fixtures.arrayOfObjects
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectContainsJSON('test_subjects.*', { // * == EACH object in here should match
-          test_str_same: "I am the same...",
+        test_str_same: "I am the same...",
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectContainsJSON should MATCH ONE object in an array with path ending with question mark', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-object-array')
       .respond({
-          statusCode: 200,
-          body: fixtures.arrayOfObjects
+        statusCode: 200,
+        body: fixtures.arrayOfObjects
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectContainsJSON('test_subjects.?', { // ? == ONE object in here should match (contains)
-          test_str: "I am a string two!",
+        test_str: "I am a string two!",
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectContainsJSON should NOT MATCH ONE object in an array with path ending with question mark', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
       .get('/test-object-array')
       .respond({
-          statusCode: 200,
-          body: fixtures.arrayOfObjects
+        statusCode: 200,
+        body: fixtures.arrayOfObjects
       })
-      .run();
+      .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .not().expectContainsJSON('test_subjects.?', { // ? == ONE object in 'test_subjects' array
-          test_str: "I am a string two nonsense!",
+        test_str: "I am a string two nonsense!",
       })
-     .toss();
-  });
+     .toss()
+  })
 
   it('expectJSONTypes should NOT match ONE object in an array with path ending with question mark', function() {
     // Mock API
@@ -492,7 +492,7 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
@@ -500,8 +500,8 @@ describe('Frisby matchers', function() {
         test_str: Joi.boolean(),
         test_int: Joi.string()
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should properly count arrays, strings, and objects', function() {
     // Mock API
@@ -511,15 +511,15 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', 3)
       .expectJSONLength('test_subjects.0', 4)
       .expectJSONLength('some_string', 9)
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should support an asterisk in the path to test all elements of an array', function() {
     // Mock API
@@ -529,13 +529,13 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', 4)
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should support an asterisk in the path to test that all elements of an array do NOT have a specified length', function() {
     // Mock API
@@ -545,15 +545,15 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .not()
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', 3)
       .expectJSONLength('test_subjects.*', 5)
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should properly count arrays, strings, and objects using <=', function() {
     // Mock API
@@ -563,15 +563,15 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '<=3')
       .expectJSONLength('test_subjects.0', '<=4')
       .expectJSONLength('some_string', '<=9')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should support an asterisk in the path to test all elements of an array using <=', function() {
     // Mock API
@@ -581,13 +581,13 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '<=4')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should properly count arrays, strings, and objects using <', function() {
     // Mock API
@@ -597,15 +597,15 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '<4')
       .expectJSONLength('test_subjects.0', '<5')
       .expectJSONLength('some_string', '<10')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should support an asterisk in the path to test all elements of an array using <', function() {
     // Mock API
@@ -615,13 +615,13 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '<5')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should properly count arrays, strings, and objects using >=', function() {
     // Mock API
@@ -631,15 +631,15 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '>=3')
       .expectJSONLength('test_subjects.0', '>=4')
       .expectJSONLength('some_string', '>=9')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should support an asterisk in the path to test all elements of an array using >=', function() {
     // Mock API
@@ -649,13 +649,13 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '>=4')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should properly count arrays, strings, and objects using >', function() {
     // Mock API
@@ -665,15 +665,15 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '>2')
       .expectJSONLength('test_subjects.0', '>3')
       .expectJSONLength('some_string', '>8')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should support an asterisk in the path to test all elements of an array using >', function() {
     // Mock API
@@ -683,13 +683,13 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '>3')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should properly count arrays, strings, and objects testing string number', function() {
     // Mock API
@@ -699,15 +699,15 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects', '3')
       .expectJSONLength('test_subjects.0', '4')
       .expectJSONLength('some_string', '9')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectJSONLength should support an asterisk in the path to test all elements of an array testing string number', function() {
     // Mock API
@@ -717,13 +717,13 @@ describe('Frisby matchers', function() {
         statusCode: 200,
         body: fixtures.arrayOfObjects
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/test-object-array', {mock: mockFn})
       .expectJSONLength('test_subjects.*', '4')
-      .toss();
-  });
+      .toss()
+  })
 
   it('expectStatus for mock request should return 404', function() {
     // Mock API
@@ -732,161 +732,161 @@ describe('Frisby matchers', function() {
       .respond({
         statusCode: 404
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/not-found', {mock: mockFn})
       .expectStatus(404)
-      .toss();
-  });
+      .toss()
+  })
 
   describe('after() callbacks', function() {
     it('should be invoked in sequence after a successful request', function () {
-      const sequence = [];
+      const sequence = []
       const mockFn = mockRequest.mock()
         .get('/test-object')
         .respond({
-            statusCode: 200,
-            body: fixtures.singleObject
+          statusCode: 200,
+          body: fixtures.singleObject
         })
-        .run();
+        .run()
       const requestFn = function () {
-        sequence.push('request');
-        return mockFn.apply(this, arguments);
-      };
+        sequence.push('request')
+        return mockFn.apply(this, arguments)
+      }
 
       frisby.create(this.test.title)
         .get('http://mock-request/test-object', {mock: requestFn})
         .expectStatus(200)
-        .after(() => { sequence.push('after-one'); })
-        .after(() => { sequence.push('after-two'); })
+        .after(() => { sequence.push('after-one') })
+        .after(() => { sequence.push('after-two') })
         .after(() => {
-          const expectedSequence = ['request', 'after-one', 'after-two'];
-          expect(sequence).to.deep.equal(expectedSequence);
+          const expectedSequence = ['request', 'after-one', 'after-two']
+          expect(sequence).to.deep.equal(expectedSequence)
         })
-        .toss();
-    });
+        .toss()
+    })
 
     describe('should not be invoked after an failed expectation', function() {
       const mockFn = mockRequest.mock()
         .get('/test-object')
         .respond({
-            statusCode: 200,
-            body: fixtures.singleObject
+          statusCode: 200,
+          body: fixtures.singleObject
         })
-        .run();
+        .run()
 
       const test = frisby.create('aaa')
         .get('http://mock-request/test-object', {mock: mockFn})
         .expectStatus(204)
-        .after(() => { expect.fail("The after function shouldn't be invoked"); });
+        .after(() => { expect.fail("The after function shouldn't be invoked") })
 
       // Intercept the raised exception to prevent Mocha from receiving it.
       test._invokeExpects = function (done) {
         try {
-          test.prototype._invokeExpects.call(test, done);
+          test.prototype._invokeExpects.call(test, done)
         } catch (e) {
-          done();
-          return;
+          done()
+          return
         }
         // If we catch the exeption, as expected, we should never get here.
-        expect.fail('The failed expectation should have raised an exception');
-      };
+        expect.fail('The failed expectation should have raised an exception')
+      }
 
-      test.toss();
-    });
+      test.toss()
+    })
 
-    it('TODO: should not be invoked after a test failure');
-  });
+    it('TODO: should not be invoked after a test failure')
+  })
 
   describe('finally() hooks', function() {
     it('should be invoked in sequence after after() hooks', function () {
-      const sequence = [];
+      const sequence = []
       const mockFn = mockRequest.mock()
         .get('/test-object')
         .respond({
-            statusCode: 200,
-            body: fixtures.singleObject
+          statusCode: 200,
+          body: fixtures.singleObject
         })
-        .run();
+        .run()
       const requestFn = function () {
-        sequence.push('request');
-        return mockFn.apply(this, arguments);
-      };
+        sequence.push('request')
+        return mockFn.apply(this, arguments)
+      }
 
       frisby.create(this.test.title)
         .get('http://mock-request/test-object', {mock: requestFn})
         .expectStatus(200)
-        .after(() => { sequence.push('after-one'); })
-        .after(() => { sequence.push('after-two'); })
-        .finally(() => { sequence.push('finally-one'); })
-        .finally(() => { sequence.push('finally-two'); })
+        .after(() => { sequence.push('after-one') })
+        .after(() => { sequence.push('after-two') })
+        .finally(() => { sequence.push('finally-one') })
+        .finally(() => { sequence.push('finally-two') })
         .finally(() => {
-          const expectedSequence = ['request', 'after-one', 'after-two', 'finally-one', 'finally-two'];
-          expect(sequence).to.deep.equal(expectedSequence);
+          const expectedSequence = ['request', 'after-one', 'after-two', 'finally-one', 'finally-two']
+          expect(sequence).to.deep.equal(expectedSequence)
         })
-        .toss();
-    });
+        .toss()
+    })
 
     describe('should be invoked after an failed expectation', function() {
       const mockFn = mockRequest.mock()
         .get('/test-object')
         .respond({
-            statusCode: 200,
-            body: fixtures.singleObject
+          statusCode: 200,
+          body: fixtures.singleObject
         })
-        .run();
+        .run()
 
-      let finallyInvoked = false;
+      let finallyInvoked = false
 
       const test = frisby.create('aaa')
         .get('http://mock-request/test-object', {mock: mockFn})
         .expectStatus(204)
-        .finally(() => { finallyInvoked = true; });
+        .finally(() => { finallyInvoked = true })
 
       // TODO: How can I ensure this has been called?
       test._finish = function (done) {
         test.constructor.prototype._finish.call(this, (err) => {
-          expect(finallyInvoked).to.be.ok;
-          done();
-        });
-      };
+          expect(finallyInvoked).to.be.ok
+          done()
+        })
+      }
 
-      test.toss();
-    });
+      test.toss()
+    })
 
     describe('before hook errors are bundled together', function () {
       const mockFn = mockRequest.mock()
         .get('/test-object')
         .respond({
-            statusCode: 200,
-            body: fixtures.singleObject
+          statusCode: 200,
+          body: fixtures.singleObject
         })
-        .run();
+        .run()
 
-      const beforeErrorMessage = 'this-is-the-before-error';
-      const finallyErrorMessage = 'this-is-the-finally-error';
+      const beforeErrorMessage = 'this-is-the-before-error'
+      const finallyErrorMessage = 'this-is-the-finally-error'
 
       const test = frisby.create('error bundling')
         .get('http://mock-request/test-object', {mock: mockFn})
         .expectStatus(200)
-        .before(() => { throw Error(beforeErrorMessage); })
-        .finally(() => { throw Error(finallyErrorMessage); });
+        .before(() => { throw Error(beforeErrorMessage) })
+        .finally(() => { throw Error(finallyErrorMessage) })
 
       // TODO: How can I ensure this has been called?
       test._finish = function (done) {
         test.constructor.prototype._finish.call(this, (err) => {
-          expect(err).to.be.an.instanceOf(MultiError);
-          expect(err.errors()).to.have.lengthOf(2);
-          expect(err.errors()[0].message).to.equal(beforeErrorMessage);
-          expect(err.errors()[1].message).to.equal(finallyErrorMessage);
-          done();
-        });
-      };
+          expect(err).to.be.an.instanceOf(MultiError)
+          expect(err.errors()).to.have.lengthOf(2)
+          expect(err.errors()[0].message).to.equal(beforeErrorMessage)
+          expect(err.errors()[1].message).to.equal(finallyErrorMessage)
+          done()
+        })
+      }
 
-      test.toss();
-    });
-  });
+      test.toss()
+    })
+  })
 
   it('Frisby basicAuth should set the correct HTTP Authorization header', function() {
 
@@ -899,7 +899,7 @@ describe('Frisby matchers', function() {
           Authorization: 'Basic ZnJpc2J5OnBhc3N3ZA=='
         }
       })
-    .run();
+    .run()
 
     frisby.create(this.test.title)
       .get('http://mock-request/basic-auth', {mock: mockFn})
@@ -908,32 +908,32 @@ describe('Frisby matchers', function() {
       .expectHeader('Authorization', 'Basic ZnJpc2J5OnBhc3N3ZA==')
       .after(function(err, res, body) {
         // Check to ensure outgoing set for basic auth
-        expect(this.current.outgoing.auth).to.deep.equal({ user: 'frisby', pass: 'passwd', sendImmediately: true });
+        expect(this.current.outgoing.auth).to.deep.equal({ user: 'frisby', pass: 'passwd', sendImmediately: true })
 
         // Check to ensure response headers contain basic auth header
-        expect(this.current.response.headers.authorization).to.equal('Basic ZnJpc2J5OnBhc3N3ZA==');
+        expect(this.current.response.headers.authorization).to.equal('Basic ZnJpc2J5OnBhc3N3ZA==')
 
       })
-    .toss();
+    .toss()
 
-  });
+  })
 
   // reference: https://github.com/vlucas/frisby/issues/213 (does not appear to be an issue in IcedFrisby)
   it('should work with a HTTP 204 responses', function() {
       // Mock API
-      var mockFn = mockRequest.mock()
+    var mockFn = mockRequest.mock()
           .get('/no-content')
           .respond({
-              statusCode: 204
+            statusCode: 204
           })
-          .run();
+          .run()
 
-      frisby.create(this.test.title)
+    frisby.create(this.test.title)
           .get('http://mock-request/no-content', {mock: mockFn})
           .expectStatus(204)
-          .toss();
+          .toss()
 
-  });
+  })
 
   it('Invalid URLs should fail with an error message', function() {
 
@@ -942,34 +942,34 @@ describe('Frisby matchers', function() {
       .expectStatus(599)
       .timeout(5)
       .exceptionHandler(function(e) {
-        expect(e.message).to.contain('Destination URL may be down or URL is invalid');
+        expect(e.message).to.contain('Destination URL may be down or URL is invalid')
       })
-    .toss();
+    .toss()
 
-  });
+  })
 
   it('should handle file uploads', function() {
     nock('http://httpbin.org', { allowUnmocked: true })
       .post('/file-upload')
       .once()
-      .reply(200, {'result': 'ok'});
+      .reply(200, {'result': 'ok'})
 
     // Intercepted with 'nock'
     frisby.create(this.test.title)
       .post('http://httpbin.org/file-upload', {
-          name: 'Test Upload',
-          file: fs.createReadStream(path.join(__dirname, 'logo-frisby.png'))
-        }, { form: true })
+        name: 'Test Upload',
+        file: fs.createReadStream(path.join(__dirname, 'logo-frisby.png'))
+      }, { form: true })
       .expectStatus(200)
-    .toss();
-  });
+    .toss()
+  })
 
   it('should allow for passing raw request body', function() {
     nock('http://example.com')
       .post('/raw')
       .reply(200, function(uri, requestBody) {
-        return requestBody;
-      });
+        return requestBody
+      })
 
     frisby.create(this.test.title)
       .post('http://example.com/raw', {}, {
@@ -977,14 +977,14 @@ describe('Frisby matchers', function() {
       })
       .expectStatus(200)
       .expectBodyContains('some body here')
-    .toss();
-  });
+    .toss()
+  })
 
   it('should allow for passing raw request body and preserve json:true option', function() {
     nock('http://httpbin.org', { allowUnmocked: true })
       .post('/json')
       .once()
-      .reply(200, {'foo': 'bar'});
+      .reply(200, {'foo': 'bar'})
 
     // Intercepted with 'nock'
     frisby.create(this.test.title)
@@ -993,18 +993,18 @@ describe('Frisby matchers', function() {
       .expectJSON({'foo': 'bar'})
       .expectHeader('Content-Type', 'application/json')
       .after(function(err, res, body) {
-        expect(this.current.outgoing.headers['content-type']).to.equal('application/json');
-        expect(this.current.outgoing.body).to.deep.equal({});
+        expect(this.current.outgoing.headers['content-type']).to.equal('application/json')
+        expect(this.current.outgoing.body).to.deep.equal({})
       })
-    .toss();
-  });
+    .toss()
+  })
 
   it('preserves a custom json header with json:true option', function() {
     nock('http://example.com')
       .post('/json')
-      .reply(200, {'foo': 'bar'});
+      .reply(200, {'foo': 'bar'})
 
-    const customContentType = 'application/json; profile=http://example.com/schema/books#';
+    const customContentType = 'application/json; profile=http://example.com/schema/books#'
 
     // Intercepted with 'nock'
     frisby.create(this.test.title)
@@ -1014,108 +1014,108 @@ describe('Frisby matchers', function() {
       .expectJSON({'foo': 'bar'})
       .expectHeader('Content-Type', 'application/json')
       .after(function(err, res, body) {
-        expect(this.current.outgoing.headers['content-type']).to.equal(customContentType);
-        expect(this.current.outgoing.body).to.deep.equal({});
+        expect(this.current.outgoing.headers['content-type']).to.equal(customContentType)
+        expect(this.current.outgoing.body).to.deep.equal({})
       })
-    .toss();
-  });
+    .toss()
+  })
 
   describe('expectBodyContains', function () {
     it('should fail when the response is empty', function () {
       nock('http://example.com')
         .post('/path')
-        .reply(201);
+        .reply(201)
 
       frisby.create(this.test.title)
         .post('http://example.com/path')
         .expectBodyContains('this-will-not-match')
         .exceptionHandler(err => {
           // TODO How can I assert that this method is called?
-          expect(err).to.be.an.instanceof(AssertionError);
-          expect(err.message).to.equal("expected '' to include 'this-will-not-match'");
+          expect(err).to.be.an.instanceof(AssertionError)
+          expect(err.message).to.equal("expected '' to include 'this-will-not-match'")
         })
-        .toss();
-    });
+        .toss()
+    })
 
-    it('TODO should fail when the response is absent');
+    it('TODO should fail when the response is absent')
     // Not sure how to reach the else block in `expectBodyContains`.
-  });
+  })
 
   describe('expectHeaderToMatch', function () {
     it('should pass when regex matches', function() {
       nock('http://httpbin.org', { allowUnmocked: true })
         .post('/path')
         .once()
-        .reply(201, "The payload", {'Location': '/path/23'});
+        .reply(201, "The payload", {'Location': '/path/23'})
 
       frisby.create(this.test.title)
         .post('http://httpbin.org/path', {foo: 'bar'})
         .expectStatus(201)
         .expectHeaderToMatch('location', /^\/path\/\d+$/)
-        .toss();
-    });
+        .toss()
+    })
 
     it('should fail when the regex does not match', function () {
       nock('http://example.com')
         .post('/path')
-        .reply(201, 'The payload', {'Location': '/something-else/23'});
+        .reply(201, 'The payload', {'Location': '/something-else/23'})
 
       frisby.create(this.test.title)
         .post('http://example.com/path')
         .expectHeaderToMatch('location', /^\/path\/\d+$/)
         .exceptionHandler(err => {
           // TODO How can I assert that this method is called?
-          expect(err).to.be.an.instanceof(AssertionError);
-          expect(err.message).to.equal("expected '/something-else/23' to match /^\\/path\\/\\d+$/");
+          expect(err).to.be.an.instanceof(AssertionError)
+          expect(err.message).to.equal("expected '/something-else/23' to match /^\\/path\\/\\d+$/")
         })
-        .toss();
-    });
+        .toss()
+    })
 
     it('should fail when the header is absent', function () {
       nock('http://example.com')
         .post('/path')
-        .reply(201);
+        .reply(201)
 
       frisby.create(this.test.title)
         .post('http://example.com/path')
         .expectHeaderToMatch('location', /^\/path\/\d+$/)
         .exceptionHandler(err => {
           // TODO How can I assert that this method is called?
-          expect(err).to.be.an.instanceof(Error);
-          expect(err.message).to.equal("Header 'location' does not match pattern '/^\\/path\\/\\d+$/' in HTTP response");
+          expect(err).to.be.an.instanceof(Error)
+          expect(err.message).to.equal("Header 'location' does not match pattern '/^\\/path\\/\\d+$/' in HTTP response")
         })
-        .toss();
-    });
-  });
+        .toss()
+    })
+  })
 
   it('afterJSON should be invoked with the body json', function () {
     nock('http://example.com')
       .get('/json')
-      .reply(200, {foo: 'bar'});
+      .reply(200, {foo: 'bar'})
 
     frisby.create(this.test.title)
       .get('http://example.com/json')
       .expectStatus(200)
       .expectJSON({foo: 'bar'})
       .afterJSON(json => {
-        expect(json).to.eql({ foo: 'bar' });
+        expect(json).to.eql({ foo: 'bar' })
       })
-      .toss();
-  });
+      .toss()
+  })
 
   it('globalSetup should be able to set baseURI', function () {
     nock('http://httpbin.org', { allowUnmocked: true })
      .post('/test')
      .once()
      .reply(200, function(uri, requestBody) {
-       return requestBody;
-     });
+       return requestBody
+     })
 
     frisby.globalSetup({
       request: {
         baseUri: 'http://httpbin.org'
       }
-    });
+    })
 
     frisby.create(this.test.title)
       .post('/test', {}, {
@@ -1124,24 +1124,24 @@ describe('Frisby matchers', function() {
       .expectStatus(200)
       .expectBodyContains('some body here')
       .after(function() {
-        expect(this.current.outgoing.uri).to.equal('http://httpbin.org/test');
+        expect(this.current.outgoing.uri).to.equal('http://httpbin.org/test')
       })
-    .toss();
+    .toss()
 
-    restoreGlobalSetup();
-  });
+    restoreGlobalSetup()
+  })
 
   it('baseUri should be able to override global setup', function() {
     nock('http://httpbin.org', { allowUnmocked: true })
      .post('/test')
      .once()
-     .reply(200, (uri, requestBody) => requestBody);
+     .reply(200, (uri, requestBody) => requestBody)
 
     frisby.globalSetup({
       request: {
         baseUri: 'http://example.com'
       }
-    });
+    })
 
     frisby.create(this.test.title)
       .baseUri('http://httpbin.org')
@@ -1151,19 +1151,19 @@ describe('Frisby matchers', function() {
       .expectStatus(200)
       .expectBodyContains('some body here')
       .after(function() {
-        expect(this.current.outgoing.uri).to.equal('http://httpbin.org/test');
+        expect(this.current.outgoing.uri).to.equal('http://httpbin.org/test')
       })
-    .toss();
+    .toss()
 
-    restoreGlobalSetup();
-  });
+    restoreGlobalSetup()
+  })
 
   describe('Other HTTP methods', function () {
     it('delete', function () {
       nock('http://example.com')
        .delete('/test')
        .query({ name: 'sally' })
-       .reply(204, (uri, requestBody) => requestBody);
+       .reply(204, (uri, requestBody) => requestBody)
 
       frisby.create(this.test.title)
         .delete('http://example.com/test', {}, {
@@ -1172,48 +1172,48 @@ describe('Frisby matchers', function() {
         })
         .expectStatus(204)
         .expectBodyContains('some body here')
-        .toss();
-    });
+        .toss()
+    })
 
     it('head', function () {
       nock('http://example.com')
        .head('/test')
        .query({ name: 'sally' })
-       .reply(204, (uri, requestBody) => requestBody);
+       .reply(204, (uri, requestBody) => requestBody)
 
       frisby.create(this.test.title)
         .head('http://example.com/test', {
           qs: { name: 'sally' }
         })
         .expectStatus(204)
-        .toss();
-    });
+        .toss()
+    })
 
     it('options', function () {
       nock('http://example.com')
        .options('/test')
        .query({ name: 'sally' })
-       .reply(204, (uri, requestBody) => requestBody);
+       .reply(204, (uri, requestBody) => requestBody)
 
       frisby.create(this.test.title)
         .options('http://example.com/test', {
           qs: { name: 'sally' }
         })
         .expectStatus(204)
-        .toss();
-    });
-  });
+        .toss()
+    })
+  })
 
   it('util.inspect should not have side effects', function () {
     // Invoking console.log() on a frisby object invokes util.inspect, which
     // in turn invokes inspect() on the frisby object. This causes side
     // effects which trigger a ("cb.call is not a function") error, which is
     // difficult to debug.
-    const test = frisby.create(this.test.title);
-    expect(test.current.inspections).to.have.lengthOf(0);
-    test.inspectJSON(() => {});
-    expect(test.current.inspections).to.have.lengthOf(1);
-    util.inspect(test);
-    expect(test.current.inspections).to.have.lengthOf(1);
-  });
-});
+    const test = frisby.create(this.test.title)
+    expect(test.current.inspections).to.have.lengthOf(0)
+    test.inspectJSON(() => {})
+    expect(test.current.inspections).to.have.lengthOf(1)
+    util.inspect(test)
+    expect(test.current.inspections).to.have.lengthOf(1)
+  })
+})

--- a/test/frisby_output.js
+++ b/test/frisby_output.js
@@ -1,86 +1,86 @@
-'use strict';
+'use strict'
 
-const chai = require('chai');
-const intercept = require("intercept-stdout");
-const nock = require('nock');
-const frisby = require('../lib/icedfrisby');
+const chai = require('chai')
+const intercept = require("intercept-stdout")
+const nock = require('nock')
+const frisby = require('../lib/icedfrisby')
 
 //
 // This spec tests and showcases the dev-friendy output features of IcedFrisby
 //
 
 // Test global setup
-var defaultGlobalSetup = frisby.globalSetup();
+var defaultGlobalSetup = frisby.globalSetup()
 var mockGlobalSetup = function() {
-    frisby.globalSetup({
-        timeout: 3000,
-        request: {
-            headers: {
-                'Content-Type': 'application/json',
-                'Accept': 'application/json',
-                'Referer': 'http://frisbyjs.com'
-            }
-        }
-    });
-};
+  frisby.globalSetup({
+    timeout: 3000,
+    request: {
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+        'Referer': 'http://frisbyjs.com'
+      }
+    }
+  })
+}
 var restoreGlobalSetup = function() {
-    frisby.globalSetup(defaultGlobalSetup);
-};
+  frisby.globalSetup(defaultGlobalSetup)
+}
 
 describe('console output', function() {
-  var warning = '\u001b[33m\u001b[1mWARNING - content-type is json but body type is not set\u001b[22m\u001b[39m\n';
+  var warning = '\u001b[33m\u001b[1mWARNING - content-type is json but body type is not set\u001b[22m\u001b[39m\n'
 
-  afterEach(restoreGlobalSetup);
+  afterEach(restoreGlobalSetup)
 
-    it('should warn developers if there is a header with \'json\' but the body type is not JSON', function() {
+  it('should warn developers if there is a header with \'json\' but the body type is not JSON', function() {
         // Mock API
-        nock('http://mock-request/', {
-                allowUnmocked: true
-            })
+    nock('http://mock-request/', {
+      allowUnmocked: true
+    })
             .post('/test-object')
             .once()
-            .reply(201);
+            .reply(201)
 
-        mockGlobalSetup();
+    mockGlobalSetup()
 
-        var stdout = "";
-        var unhook = intercept(function(txt) {
-              stdout += txt;
-        });
+    var stdout = ""
+    var unhook = intercept(function(txt) {
+      stdout += txt
+    })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .post('http://mock-request/test-object', {
-                isSomeObj: true
+              isSomeObj: true
             })
             .expectStatus(201)
-            .toss();
+            .toss()
 
-        unhook();
-        chai.assert.equal(warning, stdout, 'expect stdout to have a specific warning');
-    });
+    unhook()
+    chai.assert.equal(warning, stdout, 'expect stdout to have a specific warning')
+  })
 
-    it('should NOT warn developers that "there is a header with \'json\' but the body type is not JSON" because there is no body provided', function() {
+  it('should NOT warn developers that "there is a header with \'json\' but the body type is not JSON" because there is no body provided', function() {
         // Mock API
-        nock('http://mock-request/', {
-                allowUnmocked: true
-            })
+    nock('http://mock-request/', {
+      allowUnmocked: true
+    })
             .post('/test-object')
             .once()
             .reply(201, function(uri, requestBody) {
-                return requestBody;
-            });
+              return requestBody
+            })
 
-        var stdout = "";
-        var unhook = intercept(function(txt) {
-              stdout += txt;
-        });
+    var stdout = ""
+    var unhook = intercept(function(txt) {
+      stdout += txt
+    })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .post('http://mock-request/test-object')
             .expectStatus(201)
-            .toss();
+            .toss()
 
-        unhook();
-        chai.assert.equal("", stdout, 'expect stdout to be empty');
-    });
-});
+    unhook()
+    chai.assert.equal("", stdout, 'expect stdout to be empty')
+  })
+})

--- a/test/frisby_useApp.js
+++ b/test/frisby_useApp.js
@@ -1,112 +1,112 @@
-'use strict';
+'use strict'
 
-var fs = require('fs');
-var https = require('https');
-var path = require('path');
-var frisby = require('./../lib/icedfrisby');
-var express = require('express');
+var fs = require('fs')
+var https = require('https')
+var path = require('path')
+var frisby = require('./../lib/icedfrisby')
+var express = require('express')
 
-var chai = require('chai');
-var expect = chai.expect;
+var chai = require('chai')
+var expect = chai.expect
 
 // The following tests were adapted from:
 // https://github.com/visionmedia/supertest/blob/master/test/supertest.js
 
 describe('IcedFrisby useApp(app)', function() {
-    it('should start the http server on an ephemeral port', function() {
-        var app = express();
+  it('should start the http server on an ephemeral port', function() {
+    var app = express()
 
-        app.get('/', function(req, res) {
-            res.send('^.^');
-        });
+    app.get('/', function(req, res) {
+      res.send('^.^')
+    })
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .useApp(app)
             .get('/')
             .expectStatus(200)
             .expectBodyContains('^.^')
             .after(function(err, res, body) {
-                expect(err).to.not.exist;
+              expect(err).to.not.exist
             })
-            .toss();
-    });
+            .toss()
+  })
 
-    it('should work with an active http server', function() {
-        var app = express();
+  it('should work with an active http server', function() {
+    var app = express()
 
-        app.get('/', function(req, res) {
-            res.send('^.^');
-        });
+    app.get('/', function(req, res) {
+      res.send('^.^')
+    })
 
-        app.listen(4000, function() {
-            frisby.create(this.test.title)
+    app.listen(4000, function() {
+      frisby.create(this.test.title)
                 .useApp(app)
                 .get('/')
                 .expectStatus(200)
                 .expectBodyContains('^.^')
-                .toss();
-        });
-    });
+                .toss()
+    })
+  })
 
-    it('should start the https server on an ephemeral port', function() {
+  it('should start the https server on an ephemeral port', function() {
         // disable rejecting self signed certs for testing purposes
         // Attn Everyone: DO NOT USE THIS IN PRODUCTION
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
 
-        var app = express();
+    var app = express()
 
-        app.get('/', function(req, res) {
-            res.send('^.^');
-        });
+    app.get('/', function(req, res) {
+      res.send('^.^')
+    })
 
-        var fixtures = path.join(__dirname, '../', 'test', 'fixtures');
-        var server = https.createServer({
-            key: fs.readFileSync(path.join(fixtures, 'test_key.pem')),
-            cert: fs.readFileSync(path.join(fixtures, 'test_cert.pem'))
-        }, app);
+    var fixtures = path.join(__dirname, '../', 'test', 'fixtures')
+    var server = https.createServer({
+      key: fs.readFileSync(path.join(fixtures, 'test_key.pem')),
+      cert: fs.readFileSync(path.join(fixtures, 'test_cert.pem'))
+    }, app)
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .useApp(server)
             .get('/')
             .expectStatus(200)
             .expectBodyContains('^.^')
-            .toss();
-    });
+            .toss()
+  })
 
-    it('should work with an active https server', function() {
+  it('should work with an active https server', function() {
         // disable rejecting self signed certs for testing purposes
         // Attn Everyone: DO NOT USE THIS IN PRODUCTION
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0"
 
-        var app = express();
+    var app = express()
 
-        app.get('/', function(req, res) {
-            res.send('^.^');
-        });
+    app.get('/', function(req, res) {
+      res.send('^.^')
+    })
 
-        var fixtures = path.join(__dirname, '../', 'test', 'fixtures');
-        var server = https.createServer({
-            key: fs.readFileSync(path.join(fixtures, 'test_key.pem')),
-            cert: fs.readFileSync(path.join(fixtures, 'test_cert.pem'))
-        }, app).listen();
+    var fixtures = path.join(__dirname, '../', 'test', 'fixtures')
+    var server = https.createServer({
+      key: fs.readFileSync(path.join(fixtures, 'test_key.pem')),
+      cert: fs.readFileSync(path.join(fixtures, 'test_cert.pem'))
+    }, app).listen()
 
-        frisby.create(this.test.title)
+    frisby.create(this.test.title)
             .useApp(server)
             .get('/')
             .expectStatus(200)
             .expectBodyContains('^.^')
-            .toss();
-    });
+            .toss()
+  })
 
-    it('should throw an exception if app is not defined', function() {
-        var self = this;
+  it('should throw an exception if app is not defined', function() {
+    var self = this
 
-        var fn = function() {
-            frisby.create(self.test.title)
+    var fn = function() {
+      frisby.create(self.test.title)
                 .useApp(undefined)
-                .toss();
-        };
+                .toss()
+    }
 
-        expect(fn).to.throw('No app provided');
-    });
-});
+    expect(fn).to.throw('No app provided')
+  })
+})

--- a/test/pathMatch.js
+++ b/test/pathMatch.js
@@ -1,547 +1,547 @@
-'use strict';
+'use strict'
 
-var pm = require('../lib/pathMatch');
+var pm = require('../lib/pathMatch')
 
-var Joi = require('joi');
+var Joi = require('joi')
 
-var chai = require('chai');
-chai.should(); // setup should assertions
-chai.use(require('chai-things'));
+var chai = require('chai')
+chai.should() // setup should assertions
+chai.use(require('chai-things'))
 // chai.config.includeStack = true;
-global.expect = chai.expect;
+global.expect = chai.expect
 
 
 // JSON to use in mock tests
-var fixtures = require('./fixtures/repetition_fixture.json');
-var usersFixture = require('./fixtures/users_fixture.json');
+var fixtures = require('./fixtures/repetition_fixture.json')
+var usersFixture = require('./fixtures/users_fixture.json')
 
 
 //
 // PATH TRAVERSAL
 //
 describe('Path traversal', function() {
-    it('should fail on a bad path', function() {
-        var fn = function() {
+  it('should fail on a bad path', function() {
+    var fn = function() {
             // apply path is not exposed, so we will just use matchJSON, which calls it
-            pm.matchJSON({
-                jsonBody: { a: { } },
-                jsonTest: { },
-                path: 'a.b.c.d.e.f',
-                isNot: false
-            });
-        };
-        expect(fn).to.throw(/Cannot read property 'c' of undefined/);
-    });
+      pm.matchJSON({
+        jsonBody: { a: { } },
+        jsonTest: { },
+        path: 'a.b.c.d.e.f',
+        isNot: false
+      })
+    }
+    expect(fn).to.throw(/Cannot read property 'c' of undefined/)
+  })
 
-    it('should not fail on a bad path with isNot specified (even though this is an anti-pattern)', function() {
+  it('should not fail on a bad path with isNot specified (even though this is an anti-pattern)', function() {
         // apply path is not exposed, so we will just use matchJSON, which calls it
-        pm.matchJSON({
-            jsonBody: { a: { } },
-            jsonTest: { },
-            path: 'a.b.c.d.e.f',
-            isNot: true
-        });
-    });
-});
+    pm.matchJSON({
+      jsonBody: { a: { } },
+      jsonTest: { },
+      path: 'a.b.c.d.e.f',
+      isNot: true
+    })
+  })
+})
 
 //
 // JSON MATCH
 //
 describe('Path match JSON', function() {
 
-    describe('Sanity error checking', function() {
-        it('should fail if nothing is provided', function() {
-            var fn = function() {
-                pm.matchJSON();
-            };
-            expect(fn).to.throw('Data to match is not defined');
-        });
+  describe('Sanity error checking', function() {
+    it('should fail if nothing is provided', function() {
+      var fn = function() {
+        pm.matchJSON()
+      }
+      expect(fn).to.throw('Data to match is not defined')
+    })
 
-        it('should fail if no jsonBody is provided', function() {
-            var fn = function() {
-                pm.matchJSON({
-                    jsonBody: undefined,
-                    jsonTest: {}
-                });
-            };
-            expect(fn).to.throw('jsonBody is not defined');
-        });
-
-        it('should fail if no jsonTest is provided', function() {
-            var fn = function() {
-                pm.matchJSON({
-                    jsonBody: {},
-                    jsonTest: undefined
-                });
-            };
-            expect(fn).to.throw('jsonTest is not defined');
-        });
-    });
-
-    it('should be a function', function() {
-        expect(pm.matchJSON).to.be.a('function');
-    });
-
-    it('should match a simple json object', function() {
+    it('should fail if no jsonBody is provided', function() {
+      var fn = function() {
         pm.matchJSON({
-            jsonBody: {},
-            jsonTest: {}
-        });
-    });
+          jsonBody: undefined,
+          jsonTest: {}
+        })
+      }
+      expect(fn).to.throw('jsonBody is not defined')
+    })
 
-    it('should detect a mismatching object', function() {
-        var fn = function() {
-            pm.matchJSON({
-                jsonBody: {},
-                jsonTest: true
-            });
-        };
-        expect(fn).to.throw(/expected {} to .*? equal true/);
-    });
-
-    it('should allow a mismatching object with isNot set', function() {
+    it('should fail if no jsonTest is provided', function() {
+      var fn = function() {
         pm.matchJSON({
-            jsonBody: {},
-            jsonTest: true,
-            isNot: true
-        });
-    });
+          jsonBody: {},
+          jsonTest: undefined
+        })
+      }
+      expect(fn).to.throw('jsonTest is not defined')
+    })
+  })
 
-    it('should match the same object', function() {
-        pm.matchJSON({
-            jsonBody: fixtures,
-            jsonTest: fixtures
-        });
-    });
+  it('should be a function', function() {
+    expect(pm.matchJSON).to.be.a('function')
+  })
 
-    it('should match one object in an array with a \'?\' path', function() {
-        pm.matchJSON({
-            jsonBody: fixtures.arrayOfObjects.test_subjects,
-            jsonTest: fixtures.arrayOfObjects.test_subjects[2],
-            path: '?'
-        });
-    });
+  it('should match a simple json object', function() {
+    pm.matchJSON({
+      jsonBody: {},
+      jsonTest: {}
+    })
+  })
 
-    it('should not match any objects in an array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchJSON({
-                jsonBody: fixtures.differentNumbers,
-                jsonTest: {
-                    num: 999
-                },
-                path: '?'
-            });
-        };
+  it('should detect a mismatching object', function() {
+    var fn = function() {
+      pm.matchJSON({
+        jsonBody: {},
+        jsonTest: true
+      })
+    }
+    expect(fn).to.throw(/expected {} to .*? equal true/)
+  })
 
-        expect(fn).to.throw(/expected .*? to .*? equal .*?/);
-    });
+  it('should allow a mismatching object with isNot set', function() {
+    pm.matchJSON({
+      jsonBody: {},
+      jsonTest: true,
+      isNot: true
+    })
+  })
 
-    it('should match all objects in an array with a \'*\' path', function() {
-        pm.matchJSON({
-            jsonBody: fixtures.sameNumbers,
-            jsonTest: fixtures.sameNumbers[2],
-            path: '*'
-        });
-    });
+  it('should match the same object', function() {
+    pm.matchJSON({
+      jsonBody: fixtures,
+      jsonTest: fixtures
+    })
+  })
 
-    it('should not match any objects in an array with a \'*\' path', function() {
-        var fn = function() {
-            pm.matchJSON({
-                jsonBody: fixtures.sameNumbers,
-                jsonTest: {
-                    num: 999
-                },
-                path: '*'
-            });
-        };
+  it('should match one object in an array with a \'?\' path', function() {
+    pm.matchJSON({
+      jsonBody: fixtures.arrayOfObjects.test_subjects,
+      jsonTest: fixtures.arrayOfObjects.test_subjects[2],
+      path: '?'
+    })
+  })
 
-        expect(fn).to.throw(/expected .*? to .*? equal .*?/);
-    });
+  it('should not match any objects in an array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchJSON({
+        jsonBody: fixtures.differentNumbers,
+        jsonTest: {
+          num: 999
+        },
+        path: '?'
+      })
+    }
 
-    it('should match one object in an array with an \'array.?\' path', function() {
-        pm.matchJSON({
-            jsonBody: fixtures,
-            jsonTest: fixtures.differentNumbers[2],
-            path: 'differentNumbers.?'
-        });
-    });
+    expect(fn).to.throw(/expected .*? to .*? equal .*?/)
+  })
 
-    it('should not match one object in an array with an \'array.?\' path', function() {
-        var fn = function() {
-            pm.matchJSON({
-                jsonBody: fixtures,
-                jsonTest: {
-                    num: 999
-                },
-                path: 'differentNumbers.?'
-            });
-        };
+  it('should match all objects in an array with a \'*\' path', function() {
+    pm.matchJSON({
+      jsonBody: fixtures.sameNumbers,
+      jsonTest: fixtures.sameNumbers[2],
+      path: '*'
+    })
+  })
 
-        expect(fn).to.throw(/expected .*? to .*? equal .*?/);
-    });
+  it('should not match any objects in an array with a \'*\' path', function() {
+    var fn = function() {
+      pm.matchJSON({
+        jsonBody: fixtures.sameNumbers,
+        jsonTest: {
+          num: 999
+        },
+        path: '*'
+      })
+    }
 
-    it('should match all objects in an array with an \'array.*\' path', function() {
-        pm.matchJSON({
-            jsonBody: fixtures,
-            jsonTest: fixtures.sameNumbers[2],
-            path: 'sameNumbers.*'
-        });
-    });
+    expect(fn).to.throw(/expected .*? to .*? equal .*?/)
+  })
 
-    it('should not match any objects in an array with an \'array.*\' path', function() {
-        var fn = function() {
-            pm.matchJSON({
-                jsonBody: fixtures,
-                jsonTest: {
-                    num: 999
-                },
-                path: 'sameNumbers.*'
-            });
-        };
+  it('should match one object in an array with an \'array.?\' path', function() {
+    pm.matchJSON({
+      jsonBody: fixtures,
+      jsonTest: fixtures.differentNumbers[2],
+      path: 'differentNumbers.?'
+    })
+  })
 
-        expect(fn).to.throw(/expected .*? to .*? equal .*?/);
-    });
+  it('should not match one object in an array with an \'array.?\' path', function() {
+    var fn = function() {
+      pm.matchJSON({
+        jsonBody: fixtures,
+        jsonTest: {
+          num: 999
+        },
+        path: 'differentNumbers.?'
+      })
+    }
 
-    it('should not allow an empty array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchJSON({
-                jsonBody: [],
-                jsonTest: {
-                    num: 5
-                },
-                path: '?'
-            });
-        };
+    expect(fn).to.throw(/expected .*? to .*? equal .*?/)
+  })
 
-        expect(fn).to.throw('There are no JSON objects to match against');
-    });
-});
+  it('should match all objects in an array with an \'array.*\' path', function() {
+    pm.matchJSON({
+      jsonBody: fixtures,
+      jsonTest: fixtures.sameNumbers[2],
+      path: 'sameNumbers.*'
+    })
+  })
+
+  it('should not match any objects in an array with an \'array.*\' path', function() {
+    var fn = function() {
+      pm.matchJSON({
+        jsonBody: fixtures,
+        jsonTest: {
+          num: 999
+        },
+        path: 'sameNumbers.*'
+      })
+    }
+
+    expect(fn).to.throw(/expected .*? to .*? equal .*?/)
+  })
+
+  it('should not allow an empty array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchJSON({
+        jsonBody: [],
+        jsonTest: {
+          num: 5
+        },
+        path: '?'
+      })
+    }
+
+    expect(fn).to.throw('There are no JSON objects to match against')
+  })
+})
 
 
 //
 // JSON CONTAINS
 //
 describe('Path match Contains JSON', function() {
-    describe('Sanity error checking', function() {
-        it('should fail if nothing is provided', function() {
-            var fn = function() {
-                pm.matchContainsJSON();
-            };
-            expect(fn).to.throw('Data to match is not defined');
-        });
+  describe('Sanity error checking', function() {
+    it('should fail if nothing is provided', function() {
+      var fn = function() {
+        pm.matchContainsJSON()
+      }
+      expect(fn).to.throw('Data to match is not defined')
+    })
 
-        it('should fail if no jsonBody is provided', function() {
-            var fn = function() {
-                pm.matchContainsJSON({
-                    jsonBody: undefined,
-                    jsonTest: {}
-                });
-            };
-            expect(fn).to.throw('jsonBody is not defined');
-        });
-
-        it('should fail if no jsonTest is provided', function() {
-            var fn = function() {
-                pm.matchContainsJSON({
-                    jsonBody: {},
-                    jsonTest: undefined
-                });
-            };
-            expect(fn).to.throw('jsonTest is not defined');
-        });
-    });
-
-    it('should be a function', function() {
-        expect(pm.matchContainsJSON).to.be.a('function');
-    });
-
-    it('should match a simple json object', function() {
+    it('should fail if no jsonBody is provided', function() {
+      var fn = function() {
         pm.matchContainsJSON({
-            jsonBody: {},
-            jsonTest: {}
-        });
-    });
+          jsonBody: undefined,
+          jsonTest: {}
+        })
+      }
+      expect(fn).to.throw('jsonBody is not defined')
+    })
 
-    it('should not match a simple json object', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: {},
-                jsonTest: { bad: true }
-            });
-        };
-        expect(fn).to.throw();
-    });
-
-    it('should match a simple json object when isNot is set', function() {
+    it('should fail if no jsonTest is provided', function() {
+      var fn = function() {
         pm.matchContainsJSON({
-            jsonBody: {},
-            jsonTest: { bad: true },
-            isNot: true
-        });
-    });
+          jsonBody: {},
+          jsonTest: undefined
+        })
+      }
+      expect(fn).to.throw('jsonTest is not defined')
+    })
+  })
 
-    it('should not match a non-Array/Object in the body field', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: true,
-                jsonTest: {}
-            });
-        };
-        expect(fn).to.throw(/ContainsJSON does not support non-Array\/Object datatypes/);
-    });
+  it('should be a function', function() {
+    expect(pm.matchContainsJSON).to.be.a('function')
+  })
 
-    it('should not match a non-Array/Object in the body field', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: 111,
-                jsonTest: {}
-            });
-        };
-        expect(fn).to.throw(/ContainsJSON does not support non-Array\/Object datatypes/);
-    });
+  it('should match a simple json object', function() {
+    pm.matchContainsJSON({
+      jsonBody: {},
+      jsonTest: {}
+    })
+  })
 
-    it('should not match a non-Array/Object in the test field', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: {},
-                jsonTest: true
-            });
-        };
-        expect(fn).to.throw(/ContainsJSON does not support non-Array\/Object datatypes/);
-    });
+  it('should not match a simple json object', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: {},
+        jsonTest: { bad: true }
+      })
+    }
+    expect(fn).to.throw()
+  })
 
-    it('should not match a non-Array/Object in the test field', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: {},
-                jsonTest: 111
-            });
-        };
-        expect(fn).to.throw(/ContainsJSON does not support non-Array\/Object datatypes/);
-    });
+  it('should match a simple json object when isNot is set', function() {
+    pm.matchContainsJSON({
+      jsonBody: {},
+      jsonTest: { bad: true },
+      isNot: true
+    })
+  })
+
+  it('should not match a non-Array/Object in the body field', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: true,
+        jsonTest: {}
+      })
+    }
+    expect(fn).to.throw(/ContainsJSON does not support non-Array\/Object datatypes/)
+  })
+
+  it('should not match a non-Array/Object in the body field', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: 111,
+        jsonTest: {}
+      })
+    }
+    expect(fn).to.throw(/ContainsJSON does not support non-Array\/Object datatypes/)
+  })
+
+  it('should not match a non-Array/Object in the test field', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: {},
+        jsonTest: true
+      })
+    }
+    expect(fn).to.throw(/ContainsJSON does not support non-Array\/Object datatypes/)
+  })
+
+  it('should not match a non-Array/Object in the test field', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: {},
+        jsonTest: 111
+      })
+    }
+    expect(fn).to.throw(/ContainsJSON does not support non-Array\/Object datatypes/)
+  })
 
 
-    it('should match one object in an array with a \'?\' path', function() {
-        pm.matchContainsJSON({
-            jsonBody: fixtures.arrayOfObjects.test_subjects,
-            jsonTest: fixtures.arrayOfObjects.test_subjects[2],
-            path: '?'
-        });
-    });
+  it('should match one object in an array with a \'?\' path', function() {
+    pm.matchContainsJSON({
+      jsonBody: fixtures.arrayOfObjects.test_subjects,
+      jsonTest: fixtures.arrayOfObjects.test_subjects[2],
+      path: '?'
+    })
+  })
 
-    it('should not match any objects in an array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: fixtures.differentNumbers,
-                jsonTest: {
-                    num: 999
-                },
-                path: '?'
-            });
-        };
+  it('should not match any objects in an array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: fixtures.differentNumbers,
+        jsonTest: {
+          num: 999
+        },
+        path: '?'
+      })
+    }
 
-        expect(fn).to.throw();
-    });
+    expect(fn).to.throw()
+  })
 
-    it('should not match any objects in a single element array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: [{ num: 6 }],
-                jsonTest: {
-                    num: 999
-                },
-                path: '?'
-            });
-        };
+  it('should not match any objects in a single element array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: [{ num: 6 }],
+        jsonTest: {
+          num: 999
+        },
+        path: '?'
+      })
+    }
 
-        expect(fn).to.throw();
-    });
+    expect(fn).to.throw()
+  })
 
-    it('should match all objects in an array with a \'*\' path', function() {
-        pm.matchContainsJSON({
-            jsonBody: fixtures.sameNumbers,
-            jsonTest: fixtures.sameNumbers[2],
-            path: '*'
-        });
-    });
+  it('should match all objects in an array with a \'*\' path', function() {
+    pm.matchContainsJSON({
+      jsonBody: fixtures.sameNumbers,
+      jsonTest: fixtures.sameNumbers[2],
+      path: '*'
+    })
+  })
 
-    it('should not match any objects in an array with a \'*\' path', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: fixtures.sameNumbers,
-                jsonTest: {
-                    num: 999
-                },
-                path: '*'
-            });
-        };
+  it('should not match any objects in an array with a \'*\' path', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: fixtures.sameNumbers,
+        jsonTest: {
+          num: 999
+        },
+        path: '*'
+      })
+    }
 
-        expect(fn).to.throw();
-    });
+    expect(fn).to.throw()
+  })
 
-    it('should match one object in an array with an \'array.?\' path', function() {
-        pm.matchContainsJSON({
-            jsonBody: fixtures,
-            jsonTest: fixtures.differentNumbers[2],
-            path: 'differentNumbers.?'
-        });
-    });
+  it('should match one object in an array with an \'array.?\' path', function() {
+    pm.matchContainsJSON({
+      jsonBody: fixtures,
+      jsonTest: fixtures.differentNumbers[2],
+      path: 'differentNumbers.?'
+    })
+  })
 
-    it('should not match one object in an array with an \'array.?\' path', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: fixtures,
-                jsonTest: {
-                    num: 999
-                },
-                path: 'differentNumbers.?'
-            });
-        };
+  it('should not match one object in an array with an \'array.?\' path', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: fixtures,
+        jsonTest: {
+          num: 999
+        },
+        path: 'differentNumbers.?'
+      })
+    }
 
-        expect(fn).to.throw();
-    });
+    expect(fn).to.throw()
+  })
 
-    it('should match all objects in an array with an \'array.*\' path', function() {
-        pm.matchContainsJSON({
-            jsonBody: fixtures,
-            jsonTest: fixtures.sameNumbers[2],
-            path: 'sameNumbers.*'
-        });
-    });
+  it('should match all objects in an array with an \'array.*\' path', function() {
+    pm.matchContainsJSON({
+      jsonBody: fixtures,
+      jsonTest: fixtures.sameNumbers[2],
+      path: 'sameNumbers.*'
+    })
+  })
 
-    it('should not match any objects in an array with an \'array.*\' path and isNot set', function() {
-        pm.matchContainsJSON({
-            jsonBody: fixtures,
-            jsonTest: { num: 999 },
-            path: 'sameNumbers.*',
-            isNot: true
-        });
-    });
+  it('should not match any objects in an array with an \'array.*\' path and isNot set', function() {
+    pm.matchContainsJSON({
+      jsonBody: fixtures,
+      jsonTest: { num: 999 },
+      path: 'sameNumbers.*',
+      isNot: true
+    })
+  })
 
-    it('should not match any objects in an array with an \'array.*\' path', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: fixtures,
-                jsonTest: {
-                    num: 999
-                },
-                path: 'sameNumbers.*'
-            });
-        };
+  it('should not match any objects in an array with an \'array.*\' path', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: fixtures,
+        jsonTest: {
+          num: 999
+        },
+        path: 'sameNumbers.*'
+      })
+    }
 
-        expect(fn).to.throw();
-    });
+    expect(fn).to.throw()
+  })
 
-    it('should not match an empty array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchContainsJSON({
-                jsonBody: [],
-                jsonTest: {
-                    num: 5
-                },
-                path: '?'
-            });
-        };
+  it('should not match an empty array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchContainsJSON({
+        jsonBody: [],
+        jsonTest: {
+          num: 5
+        },
+        path: '?'
+      })
+    }
 
-        expect(fn).to.throw('There are no JSON objects to match against');
-    });
+    expect(fn).to.throw('There are no JSON objects to match against')
+  })
 
-    describe('real use case: users & passwords', function() {
+  describe('real use case: users & passwords', function() {
 
         // NOTE: the first user in usersFixture has the 'password' and 'salt' fields to represent leaked information.
         // No other users in the fixture have this.
 
-        it('should match a user\'s first name', function() {
-            pm.matchContainsJSON({
-                jsonBody: usersFixture.users[0],
-                jsonTest: {
-                    first: usersFixture.users[0].name.first
-                },
-                path: 'name'
-            });
-        });
+    it('should match a user\'s first name', function() {
+      pm.matchContainsJSON({
+        jsonBody: usersFixture.users[0],
+        jsonTest: {
+          first: usersFixture.users[0].name.first
+        },
+        path: 'name'
+      })
+    })
 
-        it('should match a user\'s email', function() {
-
-            // NOTE: the first user has a password and salt field. No other users do.
-
-            pm.matchContainsJSON({
-                jsonBody: usersFixture.users[0],
-                jsonTest: {
-                    email: usersFixture.users[0].email
-                }
-            });
-        });
-
-        it('should match one user\'s email with a \'?\' path', function() {
-            pm.matchContainsJSON({
-                jsonBody: usersFixture.users,
-                jsonTest: {
-                    email: usersFixture.users[3].email
-                },
-                path: '?'
-            });
-        });
-
-        it('should match a (nested) user\'s first name with a path', function() {
-            pm.matchContainsJSON({
-                jsonBody: usersFixture.users[0],
-                jsonTest: {
-                    first: usersFixture.users[0].name.first
-                },
-                path: 'name'
-            });
-        });
-
-        it('should match a user\'s salt and throw an error when isNot is set', function() {
+    it('should match a user\'s email', function() {
 
             // NOTE: the first user has a password and salt field. No other users do.
 
-            var fn = function() {
-                pm.matchContainsJSON({
-                    jsonBody: usersFixture.users[0],
-                    jsonTest: {
-                        salt: usersFixture.users[0].salt
-                    },
-                    isNot: true
-                });
-            };
+      pm.matchContainsJSON({
+        jsonBody: usersFixture.users[0],
+        jsonTest: {
+          email: usersFixture.users[0].email
+        }
+      })
+    })
 
-            expect(fn).to.throw();
-        });
+    it('should match one user\'s email with a \'?\' path', function() {
+      pm.matchContainsJSON({
+        jsonBody: usersFixture.users,
+        jsonTest: {
+          email: usersFixture.users[3].email
+        },
+        path: '?'
+      })
+    })
 
-        it('should match a user\'s password and throw an error when isNot is set', function() {
+    it('should match a (nested) user\'s first name with a path', function() {
+      pm.matchContainsJSON({
+        jsonBody: usersFixture.users[0],
+        jsonTest: {
+          first: usersFixture.users[0].name.first
+        },
+        path: 'name'
+      })
+    })
+
+    it('should match a user\'s salt and throw an error when isNot is set', function() {
 
             // NOTE: the first user has a password and salt field. No other users do.
 
-            var fn = function() {
-                pm.matchContainsJSON({
-                    jsonBody: usersFixture.users[0],
-                    jsonTest: {
-                        password: usersFixture.users[0].password
-                    },
-                    isNot: true
-                });
-            };
+      var fn = function() {
+        pm.matchContainsJSON({
+          jsonBody: usersFixture.users[0],
+          jsonTest: {
+            salt: usersFixture.users[0].salt
+          },
+          isNot: true
+        })
+      }
 
-            expect(fn).to.throw();
-        });
+      expect(fn).to.throw()
+    })
 
-        it('should match an object without the id present', function() {
-            pm.matchContainsJSON({
-                jsonBody: {
-                    id: 158254613,
-                    someStuff: 'some text',
-                    someNumber: 55
-                },
-                jsonTest: {
-                    someStuff: 'some text',
-                    someNumber: 55
-                }
-            });
-        });
-    });
-});
+    it('should match a user\'s password and throw an error when isNot is set', function() {
+
+            // NOTE: the first user has a password and salt field. No other users do.
+
+      var fn = function() {
+        pm.matchContainsJSON({
+          jsonBody: usersFixture.users[0],
+          jsonTest: {
+            password: usersFixture.users[0].password
+          },
+          isNot: true
+        })
+      }
+
+      expect(fn).to.throw()
+    })
+
+    it('should match an object without the id present', function() {
+      pm.matchContainsJSON({
+        jsonBody: {
+          id: 158254613,
+          someStuff: 'some text',
+          someNumber: 55
+        },
+        jsonTest: {
+          someStuff: 'some text',
+          someNumber: 55
+        }
+      })
+    })
+  })
+})
 
 
 //
@@ -549,617 +549,617 @@ describe('Path match Contains JSON', function() {
 //
 describe('Path match JSON Types', function() {
 
-    describe('Sanity error checking', function() {
-        it('should fail if nothing is provided', function() {
-            var fn = function() {
-                pm.matchJSON();
-            };
-            expect(fn).to.throw('Data to match is not defined');
-        });
+  describe('Sanity error checking', function() {
+    it('should fail if nothing is provided', function() {
+      var fn = function() {
+        pm.matchJSON()
+      }
+      expect(fn).to.throw('Data to match is not defined')
+    })
 
-        it('should fail if no jsonBody is provided', function() {
-            var fn = function() {
-                pm.matchJSON({
-                    jsonBody: undefined,
-                    jsonTest: {}
-                });
-            };
-            expect(fn).to.throw('jsonBody is not defined');
-        });
+    it('should fail if no jsonBody is provided', function() {
+      var fn = function() {
+        pm.matchJSON({
+          jsonBody: undefined,
+          jsonTest: {}
+        })
+      }
+      expect(fn).to.throw('jsonBody is not defined')
+    })
 
-        it('should fail if no jsonTest is provided', function() {
-            var fn = function() {
-                pm.matchJSON({
-                    jsonBody: {},
-                    jsonTest: undefined
-                });
-            };
-            expect(fn).to.throw('jsonTest is not defined');
-        });
-    });
+    it('should fail if no jsonTest is provided', function() {
+      var fn = function() {
+        pm.matchJSON({
+          jsonBody: {},
+          jsonTest: undefined
+        })
+      }
+      expect(fn).to.throw('jsonTest is not defined')
+    })
+  })
 
-    it('should be a function', function() {
-        expect(pm.matchJSONTypes).to.be.a('function');
-    });
+  it('should be a function', function() {
+    expect(pm.matchJSONTypes).to.be.a('function')
+  })
 
-    it('should allow a simple object', function() {
-        pm.matchJSONTypes({
-            jsonBody: fixtures.singleObject,
-            jsonTest: {
-                test_str: Joi.string().required(),
-                test_str_same: Joi.string().required(),
-                test_int: Joi.number().required(),
-                test_optional: Joi.any().optional()
-            }
-        });
-    });
+  it('should allow a simple object', function() {
+    pm.matchJSONTypes({
+      jsonBody: fixtures.singleObject,
+      jsonTest: {
+        test_str: Joi.string().required(),
+        test_str_same: Joi.string().required(),
+        test_int: Joi.number().required(),
+        test_optional: Joi.any().optional()
+      }
+    })
+  })
 
-    it('should disallow an invalid simple object', function() {
-        var fn = function() {
-            pm.matchJSONTypes({
-                jsonBody: fixtures.singleObject,
-                jsonTest: {
-                    nonexistentField: Joi.any().required(),
-                    test_str: Joi.string().required(),
-                    test_str_same: Joi.string().required(),
-                    test_int: Joi.number().required(),
-                    test_optional: Joi.any().optional()
-                }
-            });
-        };
+  it('should disallow an invalid simple object', function() {
+    var fn = function() {
+      pm.matchJSONTypes({
+        jsonBody: fixtures.singleObject,
+        jsonTest: {
+          nonexistentField: Joi.any().required(),
+          test_str: Joi.string().required(),
+          test_str_same: Joi.string().required(),
+          test_int: Joi.number().required(),
+          test_optional: Joi.any().optional()
+        }
+      })
+    }
 
-        expect(fn).to.throw('child "nonexistentField" fails because ["nonexistentField" is required]');
-    });
+    expect(fn).to.throw('child "nonexistentField" fails because ["nonexistentField" is required]')
+  })
 
-    it('should allow a simple object with isNot set', function() {
-        pm.matchJSONTypes({
-            jsonBody: fixtures.singleObject,
-            jsonTest: {
-                nonexistentField: Joi.any().required(),
-                test_str: Joi.string().required(),
-                test_str_same: Joi.string().required(),
-                test_int: Joi.number().required(),
-                test_optional: Joi.any().optional()
-            },
-            isNot: true
-        });
-    });
+  it('should allow a simple object with isNot set', function() {
+    pm.matchJSONTypes({
+      jsonBody: fixtures.singleObject,
+      jsonTest: {
+        nonexistentField: Joi.any().required(),
+        test_str: Joi.string().required(),
+        test_str_same: Joi.string().required(),
+        test_int: Joi.number().required(),
+        test_optional: Joi.any().optional()
+      },
+      isNot: true
+    })
+  })
 
-    it('should allow one object in an array with a \'?\' path', function() {
-        pm.matchJSONTypes({
-            jsonBody: fixtures.differentNumbers,
-            jsonTest: {
-                num: Joi.number().required().valid(fixtures.differentNumbers[2].num)
-            },
-            path: '?'
-        });
-    });
+  it('should allow one object in an array with a \'?\' path', function() {
+    pm.matchJSONTypes({
+      jsonBody: fixtures.differentNumbers,
+      jsonTest: {
+        num: Joi.number().required().valid(fixtures.differentNumbers[2].num)
+      },
+      path: '?'
+    })
+  })
 
-    it('should not allow any objects in an array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchJSONTypes({
-                jsonBody: fixtures.differentNumbers,
-                jsonTest: {
-                    num: Joi.number().required().valid(999)
-                },
-                path: '?'
-            });
-        };
+  it('should not allow any objects in an array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchJSONTypes({
+        jsonBody: fixtures.differentNumbers,
+        jsonTest: {
+          num: Joi.number().required().valid(999)
+        },
+        path: '?'
+      })
+    }
 
-        expect(fn).to.throw(/Expected 1 out of [0-9]+ objects to match/);
-    });
+    expect(fn).to.throw(/Expected 1 out of [0-9]+ objects to match/)
+  })
 
-    it('should allow all objects with a \'*\' path', function() {
-        pm.matchJSONTypes({
-            jsonBody: fixtures.sameNumbers,
-            jsonTest: {
-                num: Joi.number().required().valid(fixtures.sameNumbers[2].num)
-            },
-            path: '*'
-        });
-    });
+  it('should allow all objects with a \'*\' path', function() {
+    pm.matchJSONTypes({
+      jsonBody: fixtures.sameNumbers,
+      jsonTest: {
+        num: Joi.number().required().valid(fixtures.sameNumbers[2].num)
+      },
+      path: '*'
+    })
+  })
 
-    it('should not allow any objects with a \'*\' path', function() {
-        var fn = function() {
-            pm.matchJSONTypes({
-                jsonBody: fixtures.differentNumbers,
-                jsonTest: {
-                    num: Joi.number().required().valid(999)
-                },
-                path: '*'
-            });
-        };
+  it('should not allow any objects with a \'*\' path', function() {
+    var fn = function() {
+      pm.matchJSONTypes({
+        jsonBody: fixtures.differentNumbers,
+        jsonTest: {
+          num: Joi.number().required().valid(999)
+        },
+        path: '*'
+      })
+    }
 
-        expect(fn).to.throw('"num" fails because ["num" must be one of [999]]');
-    });
+    expect(fn).to.throw('"num" fails because ["num" must be one of [999]]')
+  })
 
-    it('should allow one object in an array with an \'array.?\' path', function() {
-        pm.matchJSONTypes({
-            jsonBody: fixtures,
-            jsonTest: {
-                num: Joi.number().required().valid(fixtures.differentNumbers[2].num)
-            },
-            path: 'differentNumbers.?'
-        });
-    });
+  it('should allow one object in an array with an \'array.?\' path', function() {
+    pm.matchJSONTypes({
+      jsonBody: fixtures,
+      jsonTest: {
+        num: Joi.number().required().valid(fixtures.differentNumbers[2].num)
+      },
+      path: 'differentNumbers.?'
+    })
+  })
 
-    it('should not allow any objects in an array with an \'array.?\' path', function() {
-        var fn = function() {
-            pm.matchJSONTypes({
-                jsonBody: fixtures,
-                jsonTest: {
-                    num: 999
-                },
-                path: 'differentNumbers.?'
-            });
-        };
+  it('should not allow any objects in an array with an \'array.?\' path', function() {
+    var fn = function() {
+      pm.matchJSONTypes({
+        jsonBody: fixtures,
+        jsonTest: {
+          num: 999
+        },
+        path: 'differentNumbers.?'
+      })
+    }
 
-        expect(fn).to.throw(/Expected 1 out of [0-9]+ objects to match/);
-    });
+    expect(fn).to.throw(/Expected 1 out of [0-9]+ objects to match/)
+  })
 
-    it('should allow all objects in an array with an \'array.*\' path', function() {
-        pm.matchJSONTypes({
-            jsonBody: fixtures,
-            jsonTest: {
-                num: Joi.number().required().valid(fixtures.sameNumbers[2].num)
-            },
-            path: 'sameNumbers.*'
-        });
-    });
+  it('should allow all objects in an array with an \'array.*\' path', function() {
+    pm.matchJSONTypes({
+      jsonBody: fixtures,
+      jsonTest: {
+        num: Joi.number().required().valid(fixtures.sameNumbers[2].num)
+      },
+      path: 'sameNumbers.*'
+    })
+  })
 
-    it('should not allow any objects in an array with an \'array.*\' path', function() {
-        var fn = function() {
-            pm.matchJSONTypes({
-                jsonBody: fixtures,
-                jsonTest: {
-                    num: 999
-                },
-                path: 'sameNumbers.*'
-            });
-        };
+  it('should not allow any objects in an array with an \'array.*\' path', function() {
+    var fn = function() {
+      pm.matchJSONTypes({
+        jsonBody: fixtures,
+        jsonTest: {
+          num: 999
+        },
+        path: 'sameNumbers.*'
+      })
+    }
 
-        expect(fn).to.throw('"num" fails because ["num" must be one of [999]]');
-    });
+    expect(fn).to.throw('"num" fails because ["num" must be one of [999]]')
+  })
 
-    it('should allow any object in an array with an \'array.*\' path when isNot is set', function() {
-        pm.matchJSONTypes({
-            jsonBody: fixtures,
-            jsonTest: {
-                num: Joi.boolean().required() // <-- this is completely wrong
-            },
-            path: 'sameNumbers.*',
-            isNot: true
-        });
-    });
+  it('should allow any object in an array with an \'array.*\' path when isNot is set', function() {
+    pm.matchJSONTypes({
+      jsonBody: fixtures,
+      jsonTest: {
+        num: Joi.boolean().required() // <-- this is completely wrong
+      },
+      path: 'sameNumbers.*',
+      isNot: true
+    })
+  })
 
-    it('should not allow any object in an array with an \'array.*\' path when isNot is set', function() {
-        var fn = function() {
-            pm.matchJSONTypes({
-                jsonBody: fixtures,
-                jsonTest: {
-                    num: Joi.number().required().valid(5)
-                },
-                path: 'differentNumbers.*',
-                isNot: true
-            });
-        };
+  it('should not allow any object in an array with an \'array.*\' path when isNot is set', function() {
+    var fn = function() {
+      pm.matchJSONTypes({
+        jsonBody: fixtures,
+        jsonTest: {
+          num: Joi.number().required().valid(5)
+        },
+        path: 'differentNumbers.*',
+        isNot: true
+      })
+    }
 
-        expect(fn).to.throw(/Expected all objects to be invalid but [0-9]+\/[0-9]+ objects validated successfully/);
-    });
+    expect(fn).to.throw(/Expected all objects to be invalid but [0-9]+\/[0-9]+ objects validated successfully/)
+  })
 
-    it('should not allow an empty array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchJSONTypes({
-                jsonBody: [],
-                jsonTest: {
-                    num: Joi.any().required()
-                },
-                path: '?'
-            });
-        };
+  it('should not allow an empty array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchJSONTypes({
+        jsonBody: [],
+        jsonTest: {
+          num: Joi.any().required()
+        },
+        path: '?'
+      })
+    }
 
-        expect(fn).to.throw('There are no JSON objects to match against');
-    });
+    expect(fn).to.throw('There are no JSON objects to match against')
+  })
 
-});
+})
 
 //
 // JSON LENGTH
 //
 describe('Path match JSON Length', function() {
-    describe('Sanity error checking', function() {
-        it('should fail if nothing is provided', function() {
-            var fn = function() {
-                pm.matchJSONLength();
-            };
-            expect(fn).to.throw('Data to match is not defined');
-        });
+  describe('Sanity error checking', function() {
+    it('should fail if nothing is provided', function() {
+      var fn = function() {
+        pm.matchJSONLength()
+      }
+      expect(fn).to.throw('Data to match is not defined')
+    })
 
-        it('should fail if no jsonBody is provided', function() {
-            var fn = function() {
-                pm.matchJSONLength({
-                    jsonBody: undefined,
-                    jsonTest: {}
-                });
-            };
-            expect(fn).to.throw('jsonBody is not defined');
-        });
-
-        it('should fail if no jsonTest is provided', function() {
-            var fn = function() {
-                pm.matchJSONLength({
-                    jsonBody: {},
-                    jsonTest: undefined
-                });
-            };
-            expect(fn).to.throw('jsonTest is not defined');
-        });
-    });
-
-    it('should be a function', function() {
-        expect(pm.matchJSONLength).to.be.a('function');
-    });
-
-    it('should length match a simple json object', function() {
+    it('should fail if no jsonBody is provided', function() {
+      var fn = function() {
         pm.matchJSONLength({
-            jsonBody: {},
-            jsonTest: {
-                count: 0,
-                sign: null
-            }
-        });
-    });
+          jsonBody: undefined,
+          jsonTest: {}
+        })
+      }
+      expect(fn).to.throw('jsonBody is not defined')
+    })
 
-    it('should length match a simple string object', function() {
+    it('should fail if no jsonTest is provided', function() {
+      var fn = function() {
         pm.matchJSONLength({
-            jsonBody: 'hello',
-            jsonTest: {
-                count: 5,
-                sign: null
-            }
-        });
-    });
+          jsonBody: {},
+          jsonTest: undefined
+        })
+      }
+      expect(fn).to.throw('jsonTest is not defined')
+    })
+  })
 
-    describe('simple string matching with sign', function() {
-        it('should length match a simple string object with the \'<=\' sign', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 6,
-                    sign: '<='
-                }
-            });
-        });
+  it('should be a function', function() {
+    expect(pm.matchJSONLength).to.be.a('function')
+  })
 
-        it('should length match a simple string object with the \'<=\' sign', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 5,
-                    sign: '<='
-                }
-            });
-        });
+  it('should length match a simple json object', function() {
+    pm.matchJSONLength({
+      jsonBody: {},
+      jsonTest: {
+        count: 0,
+        sign: null
+      }
+    })
+  })
 
-        it('should not length match a simple string object with the \'<=\' sign', function() {
-            var fn = function() {
-                pm.matchJSONLength({
-                    jsonBody: 'hello',
-                    jsonTest: {
-                        count: 4,
-                        sign: '<='
-                    }
-                });
-            };
-            expect(fn).to.throw(/Expected length/);
-        });
+  it('should length match a simple string object', function() {
+    pm.matchJSONLength({
+      jsonBody: 'hello',
+      jsonTest: {
+        count: 5,
+        sign: null
+      }
+    })
+  })
 
-        it('should length match a simple string object with the \'<=\' sign when isNot is set', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 4,
-                    sign: '<='
-                },
-                isNot: true
-            });
-        });
+  describe('simple string matching with sign', function() {
+    it('should length match a simple string object with the \'<=\' sign', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 6,
+          sign: '<='
+        }
+      })
+    })
 
-        it('should length match a simple string object with the \'<\' sign', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 6,
-                    sign: '<'
-                }
-            });
-        });
+    it('should length match a simple string object with the \'<=\' sign', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 5,
+          sign: '<='
+        }
+      })
+    })
 
-        it('should not length match a simple string object with the \'<\' sign', function() {
-            var fn = function() {
-                pm.matchJSONLength({
-                    jsonBody: 'hello',
-                    jsonTest: {
-                        count: 5,
-                        sign: '<'
-                    }
-                });
-            };
-            expect(fn).to.throw(/Expected length/);
-        });
-
-        it('should length match a simple string object with the \'<\' sign when isNot is set', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 5,
-                    sign: '<'
-                },
-                isNot: true
-            });
-        });
-
-        it('should not length match a simple string object with the \'>=\' sign', function() {
-            var fn = function() {
-                pm.matchJSONLength({
-                    jsonBody: 'hello',
-                    jsonTest: {
-                        count: 6,
-                        sign: '>='
-                    }
-                });
-            };
-            expect(fn).to.throw(/Expected length/);
-        });
-
-        it('should length match a simple string object with the \'>=\' sign when isNot is set', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 6,
-                    sign: '>='
-                },
-                isNot: true
-            });
-        });
-
-
-        it('should length match a simple string object with the \'>=\' sign', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 5,
-                    sign: '>='
-                }
-            });
-        });
-
-        it('should length match a simple string object with the \'>=\' sign', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 4,
-                    sign: '>='
-                }
-            });
-        });
-
-        it('should not length match a simple string object with the \'>\' sign', function() {
-            var fn = function() {
-                pm.matchJSONLength({
-                    jsonBody: 'hello',
-                    jsonTest: {
-                        count: 5,
-                        sign: '>'
-                    }
-                });
-            };
-            expect(fn).to.throw(/Expected length/);
-        });
-
-        it('should length match a simple string object with the \'>\' sign when isNot is set', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 5,
-                    sign: '>'
-                },
-                isNot: true
-            });
-        });
-
-        it('should length match a simple string object with the \'>\' sign', function() {
-            pm.matchJSONLength({
-                jsonBody: 'hello',
-                jsonTest: {
-                    count: 4,
-                    sign: '>'
-                }
-            });
-        });
-    });
-
-    it('should not length match a simple json object', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: {},
-                jsonTest: {
-                    count: 'bad'
-                }
-            });
-        };
-        expect(fn).to.throw();
-    });
-
-    it('should not length match a simple string object', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: 'bad',
-                jsonTest: {
-                    count: 999
-                }
-            });
-        };
-        expect(fn).to.throw(/Expected length/);
-    });
-
-    it('should length match a simple json object when isNot is set', function() {
+    it('should not length match a simple string object with the \'<=\' sign', function() {
+      var fn = function() {
         pm.matchJSONLength({
-            jsonBody: {},
-            jsonTest: {
-                count: 1
-            },
-            isNot: true
-        });
-    });
+          jsonBody: 'hello',
+          jsonTest: {
+            count: 4,
+            sign: '<='
+          }
+        })
+      }
+      expect(fn).to.throw(/Expected length/)
+    })
 
-    it('should length match one object in an array with a \'?\' path', function() {
+    it('should length match a simple string object with the \'<=\' sign when isNot is set', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 4,
+          sign: '<='
+        },
+        isNot: true
+      })
+    })
+
+    it('should length match a simple string object with the \'<\' sign', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 6,
+          sign: '<'
+        }
+      })
+    })
+
+    it('should not length match a simple string object with the \'<\' sign', function() {
+      var fn = function() {
         pm.matchJSONLength({
-            jsonBody: fixtures.differentSizeObjects,
-            jsonTest: {
-                count: 2
-            },
-            path: '?'
-        });
-    });
+          jsonBody: 'hello',
+          jsonTest: {
+            count: 5,
+            sign: '<'
+          }
+        })
+      }
+      expect(fn).to.throw(/Expected length/)
+    })
 
-    it('should not length match any objects in an array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: fixtures.differentSizeObjects,
-                jsonTest: {
-                    count: 999
-                },
-                path: '?'
-            });
-        };
+    it('should length match a simple string object with the \'<\' sign when isNot is set', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 5,
+          sign: '<'
+        },
+        isNot: true
+      })
+    })
 
-        expect(fn).to.throw();
-    });
-
-    it('should not length match any objects in a single element array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: [{ num: 6 }],
-                jsonTest: {
-                    count: 999
-                },
-                path: '?'
-            });
-        };
-
-        expect(fn).to.throw();
-    });
-
-    it('should length match all objects in an array with a \'*\' path', function() {
+    it('should not length match a simple string object with the \'>=\' sign', function() {
+      var fn = function() {
         pm.matchJSONLength({
-            jsonBody: fixtures.sameNumbers,
-            jsonTest: {
-                count: 1
-            },
-            path: '*'
-        });
-    });
+          jsonBody: 'hello',
+          jsonTest: {
+            count: 6,
+            sign: '>='
+          }
+        })
+      }
+      expect(fn).to.throw(/Expected length/)
+    })
 
-    it('should not length match any objects in an array with a \'*\' path', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: fixtures.sameNumbers,
-                jsonTest: {
-                    count: 999
-                },
-                path: '*'
-            });
-        };
+    it('should length match a simple string object with the \'>=\' sign when isNot is set', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 6,
+          sign: '>='
+        },
+        isNot: true
+      })
+    })
 
-        expect(fn).to.throw();
-    });
 
-    it('should length match one object in an array with an \'array.?\' path', function() {
+    it('should length match a simple string object with the \'>=\' sign', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 5,
+          sign: '>='
+        }
+      })
+    })
+
+    it('should length match a simple string object with the \'>=\' sign', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 4,
+          sign: '>='
+        }
+      })
+    })
+
+    it('should not length match a simple string object with the \'>\' sign', function() {
+      var fn = function() {
         pm.matchJSONLength({
-            jsonBody: fixtures,
-            jsonTest: {
-                count: 1
-            },
-            path: 'differentNumbers.?'
-        });
-    });
+          jsonBody: 'hello',
+          jsonTest: {
+            count: 5,
+            sign: '>'
+          }
+        })
+      }
+      expect(fn).to.throw(/Expected length/)
+    })
 
-    it('should not length match one object in an array with an \'array.?\' path', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: fixtures,
-                jsonTest: {
-                    count: 999
-                },
-                path: 'differentNumbers.?'
-            });
-        };
+    it('should length match a simple string object with the \'>\' sign when isNot is set', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 5,
+          sign: '>'
+        },
+        isNot: true
+      })
+    })
 
-        expect(fn).to.throw();
-    });
+    it('should length match a simple string object with the \'>\' sign', function() {
+      pm.matchJSONLength({
+        jsonBody: 'hello',
+        jsonTest: {
+          count: 4,
+          sign: '>'
+        }
+      })
+    })
+  })
 
-    it('should length match all objects in an array with an \'array.*\' path', function() {
-        pm.matchJSONLength({
-            jsonBody: fixtures,
-            jsonTest: {
-                count: 1
-            },
-            path: 'sameNumbers.*'
-        });
-    });
+  it('should not length match a simple json object', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: {},
+        jsonTest: {
+          count: 'bad'
+        }
+      })
+    }
+    expect(fn).to.throw()
+  })
 
-    it('should not length match any objects in an array with an \'array.*\' path and isNot set', function() {
-        pm.matchJSONLength({
-            jsonBody: fixtures,
-            jsonTest: {
-                count: 999
-            },
-            path: 'sameNumbers.*',
-            isNot: true
-        });
-    });
+  it('should not length match a simple string object', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: 'bad',
+        jsonTest: {
+          count: 999
+        }
+      })
+    }
+    expect(fn).to.throw(/Expected length/)
+  })
 
-    it('should not length match any objects in an array with an \'array.*\' path', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: fixtures,
-                jsonTest: {
-                    count: 999
-                },
-                path: 'sameNumbers.*'
-            });
-        };
+  it('should length match a simple json object when isNot is set', function() {
+    pm.matchJSONLength({
+      jsonBody: {},
+      jsonTest: {
+        count: 1
+      },
+      isNot: true
+    })
+  })
 
-        expect(fn).to.throw();
-    });
+  it('should length match one object in an array with a \'?\' path', function() {
+    pm.matchJSONLength({
+      jsonBody: fixtures.differentSizeObjects,
+      jsonTest: {
+        count: 2
+      },
+      path: '?'
+    })
+  })
 
-    it('should not length match all objects in an array with a \'*\' path and isNot set', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: fixtures.sameNumbers,
-                jsonTest: {
-                    count: 1
-                },
-                path: '*',
-                isNot: true
-            });
-        };
+  it('should not length match any objects in an array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: fixtures.differentSizeObjects,
+        jsonTest: {
+          count: 999
+        },
+        path: '?'
+      })
+    }
 
-        expect(fn).to.throw(/Expected all lengths to be invalid but/);
-    });
+    expect(fn).to.throw()
+  })
 
-    it('should not length match an empty array with a \'?\' path', function() {
-        var fn = function() {
-            pm.matchJSONLength({
-                jsonBody: [],
-                jsonTest: {
-                    count: 5
-                },
-                path: '?'
-            });
-        };
+  it('should not length match any objects in a single element array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: [{ num: 6 }],
+        jsonTest: {
+          count: 999
+        },
+        path: '?'
+      })
+    }
 
-        expect(fn).to.throw('There are no JSON objects to match against');
-    });
-});
+    expect(fn).to.throw()
+  })
+
+  it('should length match all objects in an array with a \'*\' path', function() {
+    pm.matchJSONLength({
+      jsonBody: fixtures.sameNumbers,
+      jsonTest: {
+        count: 1
+      },
+      path: '*'
+    })
+  })
+
+  it('should not length match any objects in an array with a \'*\' path', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: fixtures.sameNumbers,
+        jsonTest: {
+          count: 999
+        },
+        path: '*'
+      })
+    }
+
+    expect(fn).to.throw()
+  })
+
+  it('should length match one object in an array with an \'array.?\' path', function() {
+    pm.matchJSONLength({
+      jsonBody: fixtures,
+      jsonTest: {
+        count: 1
+      },
+      path: 'differentNumbers.?'
+    })
+  })
+
+  it('should not length match one object in an array with an \'array.?\' path', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: fixtures,
+        jsonTest: {
+          count: 999
+        },
+        path: 'differentNumbers.?'
+      })
+    }
+
+    expect(fn).to.throw()
+  })
+
+  it('should length match all objects in an array with an \'array.*\' path', function() {
+    pm.matchJSONLength({
+      jsonBody: fixtures,
+      jsonTest: {
+        count: 1
+      },
+      path: 'sameNumbers.*'
+    })
+  })
+
+  it('should not length match any objects in an array with an \'array.*\' path and isNot set', function() {
+    pm.matchJSONLength({
+      jsonBody: fixtures,
+      jsonTest: {
+        count: 999
+      },
+      path: 'sameNumbers.*',
+      isNot: true
+    })
+  })
+
+  it('should not length match any objects in an array with an \'array.*\' path', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: fixtures,
+        jsonTest: {
+          count: 999
+        },
+        path: 'sameNumbers.*'
+      })
+    }
+
+    expect(fn).to.throw()
+  })
+
+  it('should not length match all objects in an array with a \'*\' path and isNot set', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: fixtures.sameNumbers,
+        jsonTest: {
+          count: 1
+        },
+        path: '*',
+        isNot: true
+      })
+    }
+
+    expect(fn).to.throw(/Expected all lengths to be invalid but/)
+  })
+
+  it('should not length match an empty array with a \'?\' path', function() {
+    var fn = function() {
+      pm.matchJSONLength({
+        jsonBody: [],
+        jsonTest: {
+          count: 5
+        },
+        path: '?'
+      })
+    }
+
+    expect(fn).to.throw('There are no JSON objects to match against')
+  })
+})


### PR DESCRIPTION
This cleans up all the indentation across the project, which was a mix of 2 and 4 spaces, and removes semicolons. Since the previous commit touched every line in icedfrisby.js, and both of these touch every line, it makes sense to do now, since "git blame" is already useless

Closes #47.