### PR TITLE
When composed with mixins, create() should do the right thing

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -208,7 +208,9 @@ class Frisby {
    * Main Frisby method used to start new spec tests
    */
   static create (msg) {
-    return new Frisby(msg)
+    // Use `this` instead of `Frisby` so this does the right thing when
+    // composed with mixins.
+    return new this(msg)
   }
 
 


### PR DESCRIPTION
This avoids the need for mixin classes to override create().

Related to plugin support (#27).