### PR TITLE
add expectNoHeader() helper

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -687,6 +687,22 @@ class Frisby {
 
 
   /**
+   * @param {string} header - header key
+   * @return {object}
+   * @desc Asserts that a header is not present in the response
+   */
+  expectNoHeader (header) {
+    header = (header + "").toLowerCase()
+
+    this.current.expects.push(() => {
+      chai.expect(this.current.response.headers).to.not.have.property(header)
+    })
+
+    return this
+  }
+
+
+  /**
    * @param {string} content - body content
    * @return {object}
    * @desc HTTP body expect helper

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -1225,6 +1225,38 @@ describe('Frisby matchers', function() {
     })
   })
 
+  describe('expectNoHeader', function () {
+    it('should pass when a header is absent', function() {
+      nock('http://httpbin.org', { allowUnmocked: true })
+        .post('/path')
+        .once()
+        .reply(201, "The payload")
+
+      frisby.create(this.test.title)
+        .post('http://httpbin.org/path', {foo: 'bar'})
+        .expectStatus(201)
+        .expectNoHeader('Location')
+        .expectNoHeader('location')
+        .toss()
+    })
+
+    it('should fail when a header is present', function () {
+      nock('http://example.com')
+        .post('/path')
+        .reply(201, 'The payload', {'Location': '/something-else/23'})
+
+      frisby.create(this.test.title)
+        .post('http://example.com/path')
+        .expectNoHeader('Location')
+        .exceptionHandler(err => {
+          // TODO How can I assert that this method is called?
+          expect(err).to.be.an.instanceof(AssertionError)
+          expect(err.message).to.equal("expected { location: '/something-else/23' } to not have property 'location'")
+        })
+        .toss()
+    })
+  })
+
   it('afterJSON should be invoked with the body json', function () {
     nock('http://example.com')
       .get('/json')


### PR DESCRIPTION
There's a `not()` method, but that one should be removed (or replaced?) IMHO, it only works for some expectations and doesn't reset itself.

This PR adds an `expectNoHeader()` method, complementary to `expectHeader()`.