### PR TITLE
Add only() to support exclusive tests

### DIFF
--- a/API.md
+++ b/API.md
@@ -457,6 +457,10 @@ frisby.create('First test')
 .toss()
 ```
 
+### only()
+Exclusively run this test. When `toss()` is invoked, the test is wrapped in a
+Mocha `describe.only` block instead of a `describe` block.
+
 ## Inspectors
 Inspectors are useful for viewing details about HTTP requests and responses in the console.
 

--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -178,6 +178,7 @@ class Frisby {
     this.currentRequestFinished = false
     this._timeout = clone.timeout || 5000
     this.responseType = 'json'
+    this._only = false
 
     return this
   }
@@ -1135,13 +1136,21 @@ class Frisby {
   }
 
 
+  only () {
+    this._only = true
+    return this
+  }
+
+
   /**
    * Register the current Frisby test with Mocha.
    */
   toss () {
     const self = this
 
-    describe(self.current.describe, function () {
+    const describeFn = this._only ? describe.only : describe
+
+    describeFn(self.current.describe, function () {
       it("\n\t[ " + self.current.itInfo + " ]", function (done) {
         self._start(done)
       })

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "mocha": "^3.5.3",
     "mocha-lcov-reporter": "^1.2.0",
     "mock-request": "^0.1.2",
-    "nock": "^9.0.2"
+    "nock": "^9.0.2",
+    "sinon": "^4.0.0"
   },
   "main": "lib/icedfrisby",
   "files": [

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -1392,7 +1392,7 @@ describe('Frisby matchers', function() {
       sandbox = sinon.sandbox.create()
       globalMock = sandbox.mock(global, 'describe')
       globalMock.expects('describe').never()
-      describeMock = sandbox.mock(global.describe);
+      describeMock = sandbox.mock(global.describe)
       describeMock.expects('only').once()
     })
     afterEach(function () {

--- a/test/frisby_mock_request.js
+++ b/test/frisby_mock_request.js
@@ -7,6 +7,7 @@ var mockRequest = require('mock-request')
 var Joi = require('joi')
 const { AssertionError } = require('chai')
 const { MultiError } = require('verror')
+const sinon = require('sinon')
 
 // Built-in node.js
 var fs = require('fs')
@@ -1384,4 +1385,28 @@ describe('Frisby matchers', function() {
     util.inspect(test)
     expect(test.current.inspections).to.have.lengthOf(1)
   })
+
+  describe('exclusive tests', function () {
+    let sandbox, globalMock, describeMock
+    beforeEach(function () {
+      sandbox = sinon.sandbox.create()
+      globalMock = sandbox.mock(global, 'describe')
+      globalMock.expects('describe').never()
+      describeMock = sandbox.mock(global.describe);
+      describeMock.expects('only').once()
+    })
+    afterEach(function () {
+      globalMock.verify()
+      describeMock.verify()
+    })
+    afterEach(function () { sandbox.restore() })
+
+    it('should register exclusive tests', function () {
+      frisby.create(this.test.title)
+        .get('http://example.com/test')
+        .only()
+        .toss()
+    })
+  })
+
 })


### PR DESCRIPTION
As I use IcedFrisby in growing suites in Shields, I find this increasingly helpful.