### PR TITLE
Document missing functions

### DIFF
--- a/API.md
+++ b/API.md
@@ -75,7 +75,7 @@ key and content comparisons are case-insensitive.
 * Defaults: `none`
 
 ```javascript
-frisby.create('Ensure response has a proper JSON Content-Type header')
+frisby.create('Ensure response has a Content-Type header')
   .get('http://httpbin.org/get')
   .expectHeader('Content-Type', 'application/json')
 .toss();
@@ -88,7 +88,7 @@ Tests that a specific HTTP header was not received in the response
 * Defaults: `none`
 
 ```javascript
-frisby.create('Ensure response has a proper JSON Content-Type header')
+frisby.create('Ensure response has no Set-Cookie header')
   .get('http://httpbin.org/get')
   .expectNoHeader('Set-Cookie')
 .toss();

--- a/API.md
+++ b/API.md
@@ -6,7 +6,7 @@
 		- [expectHeader(key, content)](#expectheaderkey-content)
 		- [expectNoHeader(key)](#expectnoheaderkey)
 		- [expectHeaderContains(key, content)](#expectheadercontainskey-content)
-		- [expectHeaderToMatch(key, pattern)](#expectheadertomatch-pattern)
+		- [expectHeaderToMatch(key, pattern)](#expectheadertomatchkey-pattern)
 		- [expectJSON([path], json)](#expectjsonpath-json)
 		- [expectContainsJSON([path], json)](#expectcontainsjsonpath-json)
 		- [expectJSONTypes([path], schema)](#expectjsontypespath-schema)

--- a/API.md
+++ b/API.md
@@ -75,7 +75,7 @@ key and content comparisons are case-insensitive.
 * Defaults: `none`
 
 ```javascript
-frisby.create('Ensure response has a Content-Type header')
+frisby.create('Ensure response has a proper JSON Content-Type header')
   .get('http://httpbin.org/get')
   .expectHeader('Content-Type', 'application/json')
 .toss();
@@ -114,7 +114,7 @@ Tests that a names HTTP response header [matches](http://chaijs.com/api/bdd/#met
 * Defaults: `none`
 
 ```javascript
-frisby.create('Ensure response has JSON somewhere in the Content-Type header')
+frisby.create('Ensure response has JSON somewhere in the Content-Type header via regex')
   .get('http://httpbin.org/get')
   .expectHeadertoMatch('Content-Type', /.*json.*/)
 .toss();

--- a/API.md
+++ b/API.md
@@ -4,7 +4,9 @@
 	- [Expectations](#expectations)
 		- [expectStatus(code)](#expectstatuscode)
 		- [expectHeader(key, content)](#expectheaderkey-content)
+		- [expectNoHeader(key)](#expectnoheaderkey)
 		- [expectHeaderContains(key, content)](#expectheadercontainskey-content)
+		- [expectHeaderToMatch(key, pattern)](#expectheadertomatch-pattern)
 		- [expectJSON([path], json)](#expectjsonpath-json)
 		- [expectContainsJSON([path], json)](#expectcontainsjsonpath-json)
 		- [expectJSONTypes([path], schema)](#expectjsontypespath-schema)
@@ -61,7 +63,7 @@ Tests the HTTP response Status code.
 ```javascript
 frisby.create('Ensure we are dealing with a teapot')
   .get('http://httpbin.org/status/418')
-    .expectStatus(418)
+  .expectStatus(418)
 .toss()
 ```
 
@@ -75,22 +77,49 @@ key and content comparisons are case-insensitive.
 ```javascript
 frisby.create('Ensure response has a proper JSON Content-Type header')
   .get('http://httpbin.org/get')
-    .expectHeader('Content-Type', 'application/json')
+  .expectHeader('Content-Type', 'application/json')
+.toss();
+```
+
+### expectNoHeader(key)
+Tests that a specific HTTP header was not received in the response
+
+* Types: `key`: `string`
+* Defaults: `none`
+
+```javascript
+frisby.create('Ensure response has a proper JSON Content-Type header')
+  .get('http://httpbin.org/get')
+  .expectNoHeader('Set-Cookie')
 .toss();
 ```
 
 ### expectHeaderContains(key, content)
-Tests that a single HTTP response header [contains](http://chaijs.com/api/bdd/#include) the specified content. Both key and content comparisons are case-insensitive.
+Tests that a single HTTP response header [contains](http://chaijs.com/api/bdd/#method_include) the specified content. Both key and content comparisons are case-insensitive.
 
-* Types: `key`: `string`, `content`: `string, regex`
+* Types: `key`: `string`, `content`: `string`
 * Defaults: `none`
 
 ```javascript
 frisby.create('Ensure response has JSON somewhere in the Content-Type header')
   .get('http://httpbin.org/get')
-    .expectHeaderContains('Content-Type', 'json')
+  .expectHeaderContains('Content-Type', 'json')
 .toss();
 ```
+
+### expectHeaderToMatch(key, pattern)
+Tests that a names HTTP response header [matches](http://chaijs.com/api/bdd/#method_match) the specified regular expression. Key is case-insensitive.
+
+* Types: `key`: `string`, `pattern`: `regex`
+* Defaults: `none`
+
+```javascript
+frisby.create('Ensure response has JSON somewhere in the Content-Type header')
+  .get('http://httpbin.org/get')
+  .expectHeadertoMatch('Content-Type', /.*json.*/)
+.toss();
+```
+
 
 ### expectJSON([path], json)
 Tests that response body is JSON and [deeply equals](http://chaijs.com/api/bdd/#deep) the provided JSON.

--- a/API.md
+++ b/API.md
@@ -108,7 +108,7 @@ frisby.create('Ensure response has JSON somewhere in the Content-Type header')
 ```
 
 ### expectHeaderToMatch(key, pattern)
-Tests that a names HTTP response header [matches](http://chaijs.com/api/bdd/#method_match) the specified regular expression. Key is case-insensitive.
+Tests that a HTTP response header [matches](http://chaijs.com/api/bdd/#method_match) the specified regular expression. Key is case-insensitive.
 
 * Types: `key`: `string`, `pattern`: `regex`
 * Defaults: `none`


### PR DESCRIPTION
Added `expectNoHeader` and `expectHeaderToMatch` into API.md - were available in the library but not documented