### PR TITLE
Drop support for Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 7
+  - 8
   - 6
 after_script:
   - npm run coverage && coveralls < coverage/lcov.info && rm -rf coverage


### PR DESCRIPTION
Since Node 8 was released, we should test on that, and I'd suggest, drop support for Node 7 which was pre-release.