### PR TITLE
Update for ES6

### DIFF
--- a/lib/icedfrisby.js
+++ b/lib/icedfrisby.js
@@ -28,8 +28,7 @@ const util = require('util')
 const { errorFromList } = require('verror')
 
 
-// setup defaults
-const _icedfrisbyDefaults = _.constant({
+const _icedfrisbyDefaults = () => ({
   request: {
     headers: {},
     inspectOnFailure: false,
@@ -135,12 +134,10 @@ class Frisby {
   constructor (msg) {
     const clone = _.cloneDeep(Frisby.globalSetup())
 
-    if(clone.request && clone.request.headers) {
-      const headers = {}
-      _.forEach(clone.request.headers, function(val, key) {
-        headers[(key+"").toLowerCase()] = val+""
-      })
-      clone.request.headers = headers
+    if (clone.request && clone.request.headers) {
+      clone.request.headers = _.mapKeys(
+        clone.request.headers,
+        (value, key) => key.toLowerCase())
     }
 
     // Optional exception handler
@@ -286,14 +283,13 @@ class Frisby {
 
 
   /**
-   * @param {object} headers - header object {k;v, k:v}
+   * @param {object} headers - header object {k:v, k:v}
    * @return {object}
    * @desc Add group of HTTP headers together
    */
   addHeaders (headers) {
-    const self = this
-    _.forEach(headers, function(val, key) {
-      self.addHeader(key, val)
+    Object.keys(headers).forEach(key => {
+      this.addHeader(key, headers[key])
     })
     return this
   }
@@ -431,8 +427,7 @@ class Frisby {
    * @desc _request object
    */
   _request () {
-    const self = this
-    const args = _.slice(arguments)
+    const args = Array.from(arguments)
     const method = args.shift()
     const uri = typeof args[0] === 'string' && args.shift()
     let data = typeof args[0] === 'object' && args.shift()
@@ -451,7 +446,7 @@ class Frisby {
     }
 
     // Merge 'current' request options for current request
-    _.extend(outgoing, this.current.request, params || {})
+    Object.assign(outgoing, this.current.request, params || {})
 
     // Normalize content-type
     const contentTypeKey = _hasHeader('content-type', outgoing.headers)
@@ -527,10 +522,10 @@ class Frisby {
     // Add the topic for the specified request to the context of the current
     // batch used by this suite.
     //
-    this.current.it = function (cb) {
-      self.currentRequestFinished = false
+    this.current.it = cb => {
+      this.currentRequestFinished = false
       const start = (new Date()).getTime()
-      const runCallback = function(err, res, body) {
+      const runCallback = (err, res, body) => {
 
         // Timeout is now handled by request
         if(err) {
@@ -539,17 +534,14 @@ class Frisby {
 
         const diff = (new Date()).getTime() - start
 
-        self.currentRequestFinished = {err: err, res: res, body: body, req: outgoing}
+        this.currentRequestFinished = {err: err, res: res, body: body, req: outgoing}
 
-        // Convert header names to lowercase
-        const headers = {}
+        let headers = {}
         if (res) {
-          _.forEach(res.headers, function(val, key) {
-            headers[(key+"").toLowerCase()] = val
-          })
+          headers = _.mapKeys(res.headers, (value, key) => key.toLowerCase())
         }
         // Store relevant current response parts
-        self.current.response = {
+        this.current.response = {
           error: err,
           status: (res ? res.statusCode : 599), // use 599 - network connect timeout error
           headers: headers,
@@ -559,11 +551,11 @@ class Frisby {
 
         // call caller's callback
         if (cb && typeof cb === "function") {
-          cb(self.current.response)
+          cb(this.current.response)
         }
       }
 
-      outgoing.timeout = self._timeout
+      outgoing.timeout = this._timeout
 
       let req = null
 
@@ -598,9 +590,8 @@ class Frisby {
    * @desc HTTP max response time expect helper
    */
   expectMaxResponseTime (ms) {
-    const self = this
-    this.current.expects.push(function() {
-      chai.expect(self.current.response.time).to.be.lessThan(ms)
+    this.current.expects.push(() => {
+      chai.expect(this.current.response.time).to.be.lessThan(ms)
     })
     return this
   }
@@ -612,9 +603,8 @@ class Frisby {
    * @desc HTTP status code expect helper
    */
   expectStatus (statusCode) {
-    const self = this
-    this.current.expects.push(function() {
-      chai.expect(self.current.response.status).to.equal(statusCode)
+    this.current.expects.push(() => {
+      chai.expect(this.current.response.status).to.equal(statusCode)
     })
     return this
   }
@@ -748,7 +738,7 @@ class Frisby {
    */
   expectJSONTypes (/* [tree], jsonTest */) {
     const self = this
-    const args = _.slice(arguments)
+    const args = Array.from(arguments)
     const path = typeof args[0] === 'string' && args.shift()
     const jsonTest = typeof args[0] === 'object' && args.shift()
 
@@ -769,17 +759,16 @@ class Frisby {
    * @desc Helper to check JSON response body exactly matches a provided object
    */
   expectJSON (jsonTest) {
-    const self = this
-    const args = _.slice(arguments)
+    const args = Array.from(arguments)
     const path = typeof args[0] === 'string' && args.shift()
     jsonTest = typeof args[0] === 'object' && args.shift()
 
-    this.current.expects.push(function() {
+    this.current.expects.push(() => {
       pm.matchJSON({
-        jsonBody: _jsonParse(self.current.response.body),
-        jsonTest: jsonTest,
-        isNot: self.current.isNot,
-        path: path
+        jsonBody: _jsonParse(this.current.response.body),
+        jsonTest,
+        isNot: this.current.isNot,
+        path,
       })
     })
     return this
@@ -792,17 +781,16 @@ class Frisby {
    * @desc Helper to check JSON response contains a provided object
    */
   expectContainsJSON (jsonTest) {
-    const self = this
-    const args = _.slice(arguments)
+    const args = Array.from(arguments)
     const path = typeof args[0] === 'string' && args.shift()
     jsonTest = typeof args[0] === 'object' && args.shift()
 
-    this.current.expects.push(function() {
+    this.current.expects.push(() => {
       pm.matchContainsJSON({
-        jsonBody: _jsonParse(self.current.response.body),
-        jsonTest: jsonTest,
-        isNot: self.current.isNot,
-        path: path
+        jsonBody: _jsonParse(this.current.response.body),
+        jsonTest,
+        isNot: this.current.isNot,
+        path,
       })
     })
     return this
@@ -815,8 +803,7 @@ class Frisby {
    * @desc Helper to check response body as JSON and check array or object length
    */
   expectJSONLength (expectedLength) {
-    const self = this
-    const args = _.slice(arguments)
+    const args = Array.from(arguments)
     const path = _.isString(args[0]) && args.shift() // optional 1st parameter
     expectedLength = (_.isNumber(args[0]) || _.isString(args[0])) && args.shift() // 1st or 2nd parameter
     let lengthSegments = null
@@ -826,7 +813,7 @@ class Frisby {
       const sign = /\D+/.exec(expectedLength)
       lengthSegments = {
         count: parseInt(/\d+/.exec(expectedLength), 10),
-        sign: sign ? _.trim(sign) : null // extract the sign, e.g. <, <=, >, >= and trim out whitespace
+        sign: sign ? sign[0].trim() : null // extract the sign, e.g. <, <=, >, >= and trim out whitespace
       }
     } else {
       lengthSegments = {
@@ -835,12 +822,12 @@ class Frisby {
       }
     }
 
-    this.current.expects.push(function () {
+    this.current.expects.push(() => {
       pm.matchJSONLength({
-        jsonBody: _jsonParse(self.current.response.body),
+        jsonBody: _jsonParse(this.current.response.body),
         jsonTest: lengthSegments, // we aren't testing any JSON here, just use this to pass in the length segments
-        isNot: self.current.isNot,
-        path: path
+        isNot: this.current.isNot,
+        path,
       })
     })
 

--- a/lib/pathMatch.js
+++ b/lib/pathMatch.js
@@ -61,7 +61,7 @@ function applyPath(path, jsonBody, isNot) {
 
   try {
     // break apart the path and iterate through the keys to traverse through the JSON object
-    _.forEach(pathSegments, function(segment) {
+    pathSegments.forEach(segment => {
       // if the next 'segment' isn't actually a special character, traverse through the object
       if('*' !== segment && '?' !== segment) {
         jsonBody = jsonBody[segment]
@@ -76,10 +76,7 @@ This issue was suppressed because you specified the isNot option. This behavior 
     }
   }
 
-  return {
-    lastOption: lastOption,
-    jsonBody: jsonBody
-  }
+  return { lastOption, jsonBody }
 }
 
 // creates and returns an error object saying 1 of X objects should have matched
@@ -108,7 +105,7 @@ pathMatch.matchJSON = function(check) {
     // assert that jsonBody is an array
     checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-    _.forEach(check.jsonBody, function(json) {
+    check.jsonBody.forEach(json => {
       if (check.isNot) {
         expect(json).to.not.deep.equal(check.jsonTest)
       } else {
@@ -170,7 +167,7 @@ pathMatch.matchContainsJSON = function(check) {
     // assert that jsonBody is an array
     checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-    _.forEach(check.jsonBody, function(json) {
+    check.jsonBody.forEach(json => {
       if (check.isNot) {
         expect(json).to.not.containSubset(check.jsonTest)
       } else {
@@ -243,8 +240,8 @@ pathMatch.matchJSONTypes = function(check) {
   if('*' === lastOption) {
     checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-    _.forEach(check.jsonBody, function(json) {
-      // expect(json).toContainJsonTypes(jsonTest, self.current.isNot);
+    check.jsonBody.forEach(json => {
+      // expect(json).toContainJsonTypes(jsonTest, self.current.isNot)
       Joi.validate(json, check.jsonTest, function(err, value) {
         if (err) {
           if (check.isNot) {
@@ -336,7 +333,7 @@ pathMatch.matchJSONLength = function(check) {
   if ('*' === lastOption) {
     checkTypes.assert.array(check.jsonBody, "Expected an Array in the path '" + check.path + "' but got " + typeof(check.jsonBody))
 
-    _.forEach(check.jsonBody, function(json) {
+    check.jsonBody.forEach(json => {
       try {
         expectLength(json, check.jsonTest)
       } catch (err) {
@@ -376,7 +373,7 @@ pathMatch.matchJSONLength = function(check) {
       throw new Error("There are no JSON objects to match against")
     }
 
-    _.forEach(check.jsonBody, function(json) {
+    check.jsonBody.forEach(json => {
       try {
         expectLength(json, check.jsonTest)
       } catch (err) {


### PR DESCRIPTION
- Use arrow functions where they improve clarity
- Don’t use lodash where vanilla ES6 works fine